### PR TITLE
Fixed defect in default version check

### DIFF
--- a/aws-cloudformation-resourcedefaultversion/src/main/java/software/amazon/cloudformation/resourcedefaultversion/CreateHandler.java
+++ b/aws-cloudformation-resourcedefaultversion/src/main/java/software/amazon/cloudformation/resourcedefaultversion/CreateHandler.java
@@ -1,6 +1,5 @@
 package software.amazon.cloudformation.resourcedefaultversion;
 
-import com.google.common.base.Strings;
 import software.amazon.awssdk.awscore.exception.AwsServiceException;
 import software.amazon.awssdk.services.cloudformation.CloudFormationClient;
 import software.amazon.awssdk.services.cloudformation.model.DescribeTypeRequest;
@@ -8,7 +7,6 @@ import software.amazon.awssdk.services.cloudformation.model.DescribeTypeResponse
 import software.amazon.awssdk.services.cloudformation.model.SetTypeDefaultVersionRequest;
 import software.amazon.awssdk.services.cloudformation.model.SetTypeDefaultVersionResponse;
 import software.amazon.cloudformation.exceptions.CfnAlreadyExistsException;
-import software.amazon.cloudformation.exceptions.CfnInvalidRequestException;
 import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
 import software.amazon.cloudformation.proxy.CallChain;
 import software.amazon.cloudformation.proxy.Logger;
@@ -56,17 +54,6 @@ public class CreateHandler extends BaseHandlerStd {
                              final ResourceModel model) throws AwsServiceException {
         final DescribeTypeRequest translateToReadRequest = Translator.translateToReadRequest(model);
         final DescribeTypeResponse response = proxyClient.injectCredentialsAndInvokeV2(translateToReadRequest, proxyClient.client()::describeType);
-        return response.defaultVersionId().equals(getDefaultVersionId(model));
-    }
-
-    private String getDefaultVersionId(final ResourceModel resourceModel) {
-
-        if (!Strings.isNullOrEmpty(resourceModel.getVersionId())) {
-            return resourceModel.getVersionId();
-        } else if (!Strings.isNullOrEmpty(resourceModel.getArn())) {
-            return resourceModel.getArn().substring(resourceModel.getArn().lastIndexOf("/") + 1);
-        } else {
-            throw new CfnInvalidRequestException("Could not determine version from resource model");
-        }
+        return response.isDefaultVersion();
     }
 }

--- a/aws-cloudformation-resourcedefaultversion/src/test/java/software/amazon/cloudformation/resourcedefaultversion/CreateHandlerTest.java
+++ b/aws-cloudformation-resourcedefaultversion/src/test/java/software/amazon/cloudformation/resourcedefaultversion/CreateHandlerTest.java
@@ -44,14 +44,14 @@ public class CreateHandlerTest extends AbstractMockTestBase<CloudFormationClient
             .thenReturn(setTypeDefaultVersionResponse);
 
         final DescribeTypeResponse describeTypeResponsePre = DescribeTypeResponse.builder()
-            .arn("arn:aws:cloudformation:us-west-2:123456789012:type/resource/AWS-Demo-Resource/00000001")
-            .defaultVersionId("00000001")
+            .arn("arn:aws:cloudformation:us-west-2:123456789012:type/resource/AWS-Demo-Resource/00000002")
+            .isDefaultVersion(false)
             .type("RESOURCE")
             .typeName("AWS::Demo::Resource")
             .build();
         final DescribeTypeResponse describeTypeResponsePost = DescribeTypeResponse.builder()
             .arn("arn:aws:cloudformation:us-west-2:123456789012:type/resource/AWS-Demo-Resource/00000002")
-            .defaultVersionId("00000002")
+            .isDefaultVersion(true)
             .type("RESOURCE")
             .typeName("AWS::Demo::Resource")
             .build();
@@ -68,7 +68,6 @@ public class CreateHandlerTest extends AbstractMockTestBase<CloudFormationClient
         final ResourceModel resourceModelResult = ResourceModel.builder()
             .arn("arn:aws:cloudformation:us-west-2:123456789012:type/resource/AWS-Demo-Resource/00000002")
             .typeName("AWS::Demo::Resource")
-            .versionId("00000002")
             .build();
 
         assertThat(response).isNotNull();
@@ -95,14 +94,14 @@ public class CreateHandlerTest extends AbstractMockTestBase<CloudFormationClient
             .thenReturn(setTypeDefaultVersionResponse);
 
         final DescribeTypeResponse describeTypeResponsePre = DescribeTypeResponse.builder()
-            .arn("arn:aws:cloudformation:us-west-2:123456789012:type/resource/AWS-Demo-Resource/00000001")
-            .defaultVersionId("00000001")
+            .arn("arn:aws:cloudformation:us-west-2:123456789012:type/resource/AWS-Demo-Resource/00000002")
+            .isDefaultVersion(false)
             .type("RESOURCE")
             .typeName("AWS::Demo::Resource")
             .build();
         final DescribeTypeResponse describeTypeResponsePost = DescribeTypeResponse.builder()
             .arn("arn:aws:cloudformation:us-west-2:123456789012:type/resource/AWS-Demo-Resource/00000002")
-            .defaultVersionId("00000002")
+            .isDefaultVersion(true)
             .type("RESOURCE")
             .typeName("AWS::Demo::Resource")
             .build();
@@ -117,7 +116,6 @@ public class CreateHandlerTest extends AbstractMockTestBase<CloudFormationClient
         final ResourceModel resourceModelResult = ResourceModel.builder()
             .arn("arn:aws:cloudformation:us-west-2:123456789012:type/resource/AWS-Demo-Resource/00000002")
             .typeName("AWS::Demo::Resource")
-            .versionId("00000002")
             .build();
 
         final ProgressEvent<ResourceModel, CallbackContext> response = handler.handleRequest(proxy, request, null, loggerProxy);
@@ -176,7 +174,7 @@ public class CreateHandlerTest extends AbstractMockTestBase<CloudFormationClient
         // verifies behaviour if type was deregistered out of band (timing conflict)
         final DescribeTypeResponse describeTypeResponse = DescribeTypeResponse.builder()
             .arn("arn:aws:cloudformation:us-west-2:123456789012:type/resource/AWS-Demo-Resource/00000001")
-            .defaultVersionId("00000001")
+            .isDefaultVersion(false)
             .type("RESOURCE")
             .typeName("AWS::Demo::Resource")
             .build();
@@ -218,7 +216,7 @@ public class CreateHandlerTest extends AbstractMockTestBase<CloudFormationClient
 
         final DescribeTypeResponse describeTypeResponse = DescribeTypeResponse.builder()
             .arn("arn:aws:cloudformation:us-west-2:123456789012:type/resource/AWS-Demo-Resource/00000001")
-            .defaultVersionId("00000001")
+            .isDefaultVersion(true)
             .type("RESOURCE")
             .typeName("AWS::Demo::Resource")
             .build();


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* Missed this commit on #4 before merging. Fixes the handling of default version checks for `AWS::CloudFormation::ResourceDefaultVersion`.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
