### PR TITLE
Adds required S3 permissions to the schema.

### DIFF
--- a/aws-cloudformation-resourcedefaultversion/pom.xml
+++ b/aws-cloudformation-resourcedefaultversion/pom.xml
@@ -35,7 +35,7 @@
         <dependency>
             <groupId>software.amazon.cloudformation</groupId>
             <artifactId>aws-cloudformation-rpdk-java-plugin</artifactId>
-            <version>2.0.1</version>
+            <version>2.0.2</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/org.projectlombok/lombok -->
         <dependency>

--- a/aws-cloudformation-resourcedefaultversion/src/test/java/software/amazon/cloudformation/resourcedefaultversion/CreateHandlerTest.java
+++ b/aws-cloudformation-resourcedefaultversion/src/test/java/software/amazon/cloudformation/resourcedefaultversion/CreateHandlerTest.java
@@ -159,7 +159,7 @@ public class CreateHandlerTest extends AbstractMockTestBase<CloudFormationClient
         assertThat(response.getCallbackDelaySeconds()).isEqualTo(0);
         assertThat(response.getResourceModels()).isNull();
         assertThat(response.getResourceModel()).isEqualToComparingFieldByField(resourceModel);
-        assertThat(response.getMessage()).isEqualTo("Exception=[class software.amazon.awssdk.services.cloudformation.model.TypeNotFoundException] ErrorCode=[404],  ErrorMessage=[Type not found]");
+        assertThat(response.getMessage()).isEqualTo("Type not found (Service: null, Status Code: 0, Request ID: null, Extended Request ID: null)");
         assertThat(response.getErrorCode()).isEqualTo(HandlerErrorCode.NotFound);
     }
 
@@ -199,7 +199,7 @@ public class CreateHandlerTest extends AbstractMockTestBase<CloudFormationClient
         assertThat(response.getCallbackDelaySeconds()).isEqualTo(0);
         assertThat(response.getResourceModels()).isNull();
         assertThat(response.getResourceModel()).isEqualToComparingFieldByField(resourceModel);
-        assertThat(response.getMessage()).isEqualTo("Exception=[class software.amazon.awssdk.services.cloudformation.model.TypeNotFoundException] ErrorCode=[404],  ErrorMessage=[Type not found]");
+        assertThat(response.getMessage()).isEqualTo("Type not found (Service: null, Status Code: 0, Request ID: null, Extended Request ID: null)");
         assertThat(response.getErrorCode()).isEqualTo(HandlerErrorCode.NotFound);
     }
 

--- a/aws-cloudformation-resourcedefaultversion/src/test/java/software/amazon/cloudformation/resourcedefaultversion/ReadHandlerTest.java
+++ b/aws-cloudformation-resourcedefaultversion/src/test/java/software/amazon/cloudformation/resourcedefaultversion/ReadHandlerTest.java
@@ -87,7 +87,7 @@ public class ReadHandlerTest extends AbstractMockTestBase<CloudFormationClient> 
         assertThat(response.getCallbackDelaySeconds()).isEqualTo(0);
         assertThat(response.getResourceModels()).isNull();
         assertThat(response.getResourceModel()).isEqualToComparingFieldByField(resourceModel);
-        assertThat(response.getMessage()).isEqualTo("Exception=[class software.amazon.awssdk.services.cloudformation.model.TypeNotFoundException] ErrorCode=[404],  ErrorMessage=[Type not found]");
+        assertThat(response.getMessage()).isEqualTo("Type not found (Service: null, Status Code: 0, Request ID: null, Extended Request ID: null)");
         assertThat(response.getErrorCode()).isEqualTo(HandlerErrorCode.NotFound);
     }
 }

--- a/aws-cloudformation-resourcedefaultversion/src/test/java/software/amazon/cloudformation/resourcedefaultversion/UpdateHandlerTest.java
+++ b/aws-cloudformation-resourcedefaultversion/src/test/java/software/amazon/cloudformation/resourcedefaultversion/UpdateHandlerTest.java
@@ -141,8 +141,7 @@ public class UpdateHandlerTest extends AbstractMockTestBase<CloudFormationClient
         assertThat(response.getCallbackContext()).isNotNull();
         assertThat(response.getCallbackDelaySeconds()).isEqualTo(0);
         assertThat(response.getResourceModels()).isNull();
-        assertThat(response.getResourceModel()).isEqualToComparingFieldByField(resourceModel);
-        assertThat(response.getMessage()).isEqualTo("Exception=[class software.amazon.awssdk.services.cloudformation.model.TypeNotFoundException] ErrorCode=[404],  ErrorMessage=[Type not found]");
+        assertThat(response.getMessage()).isEqualTo("Type not found (Service: null, Status Code: 0, Request ID: null, Extended Request ID: null)");
         assertThat(response.getErrorCode()).isEqualTo(HandlerErrorCode.NotFound);
     }
 }

--- a/aws-cloudformation-resourceversion/aws-cloudformation-resourceversion.json
+++ b/aws-cloudformation-resourceversion/aws-cloudformation-resourceversion.json
@@ -132,7 +132,9 @@
         "cloudformation:DescribeTypeRegistration",
         "cloudformation:ListTypeVersions",
         "cloudformation:RegisterType",
-        "iam:PassRole"
+        "iam:PassRole",
+        "s3:GetObject",
+        "s3:ListBucket"
       ]
     },
     "read": {

--- a/aws-cloudformation-resourceversion/pom.xml
+++ b/aws-cloudformation-resourceversion/pom.xml
@@ -35,7 +35,7 @@
         <dependency>
             <groupId>software.amazon.cloudformation</groupId>
             <artifactId>aws-cloudformation-rpdk-java-plugin</artifactId>
-            <version>2.0.1</version>
+            <version>2.0.2</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/org.projectlombok/lombok -->
         <dependency>

--- a/aws-cloudformation-resourceversion/resource-role.yaml
+++ b/aws-cloudformation-resourceversion/resource-role.yaml
@@ -30,6 +30,8 @@ Resources:
                 - "cloudformation:ListTypes"
                 - "cloudformation:RegisterType"
                 - "iam:PassRole"
+                - "s3:GetObject"
+                - "s3:ListBucket"
                 Resource: "*"
 Outputs:
   ExecutionRoleArn:

--- a/aws-cloudformation-resourceversion/src/test/java/software/amazon/cloudformation/resourceversion/CreateHandlerTest.java
+++ b/aws-cloudformation-resourceversion/src/test/java/software/amazon/cloudformation/resourceversion/CreateHandlerTest.java
@@ -66,7 +66,7 @@ public class CreateHandlerTest extends AbstractMockTestBase<CloudFormationClient
         assertThat(response.getCallbackDelaySeconds()).isEqualTo(0);
         assertThat(response.getResourceModels()).isNull();
         assertThat(response.getResourceModel()).isEqualTo(request.getDesiredResourceState());
-        assertThat(response.getMessage()).isEqualTo("Exception=[class software.amazon.awssdk.services.cloudformation.model.CfnRegistryException] ErrorCode=[500],  ErrorMessage=[some exception]");
+        assertThat(response.getMessage()).isEqualTo("some exception (Service: null, Status Code: 0, Request ID: null, Extended Request ID: null)");
         assertThat(response.getErrorCode()).isEqualTo(HandlerErrorCode.GeneralServiceException);
     }
 
@@ -345,7 +345,7 @@ public class CreateHandlerTest extends AbstractMockTestBase<CloudFormationClient
         assertThat(response.getCallbackDelaySeconds()).isEqualTo(0);
         assertThat(response.getResourceModels()).isNull();
         assertThat(response.getResourceModel()).isEqualToComparingFieldByField(resourceModelResult);
-        assertThat(response.getMessage()).isEqualTo("Exception=[class software.amazon.awssdk.services.cloudformation.model.CfnRegistryException] ErrorCode=[500],  ErrorMessage=[some exception]");
+        assertThat(response.getMessage()).isEqualTo("some exception (Service: null, Status Code: 0, Request ID: null, Extended Request ID: null)");
         assertThat(response.getErrorCode()).isEqualTo(HandlerErrorCode.GeneralServiceException);
     }
 
@@ -388,7 +388,7 @@ public class CreateHandlerTest extends AbstractMockTestBase<CloudFormationClient
         assertThat(response.getCallbackDelaySeconds()).isEqualTo(0);
         assertThat(response.getResourceModels()).isNull();
         assertThat(response.getResourceModel()).isEqualToComparingFieldByField(resourceModel);
-        assertThat(response.getMessage()).isEqualTo("Exception=[class software.amazon.awssdk.services.cloudformation.model.CfnRegistryException] ErrorCode=[500],  ErrorMessage=[some exception]");
+        assertThat(response.getMessage()).isEqualTo("some exception (Service: null, Status Code: 0, Request ID: null, Extended Request ID: null)");
         assertThat(response.getErrorCode()).isEqualTo(HandlerErrorCode.GeneralServiceException);
     }
 

--- a/aws-cloudformation-stackset/pom.xml
+++ b/aws-cloudformation-stackset/pom.xml
@@ -41,7 +41,7 @@
         <dependency>
             <groupId>software.amazon.cloudformation</groupId>
             <artifactId>aws-cloudformation-rpdk-java-plugin</artifactId>
-            <version>2.0.0</version>
+            <version>2.0.2</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/software.amazon.awssdk/cloudformation -->
         <dependency>


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* Recent changes to the Registry Service auth model require the caller to have S3 permissions for object retrieval over the `SchemaHandlerPackage`


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
