### PR TITLE
AWS::CloudFormation::ResourceVersion - Define createOnlyProperties

### DIFF
--- a/aws-cloudformation-resourceversion/aws-cloudformation-resourceversion.json
+++ b/aws-cloudformation-resourceversion/aws-cloudformation-resourceversion.json
@@ -110,18 +110,21 @@
   "readOnlyProperties": [
     "/properties/Arn",
     "/properties/Description",
-    "/properties/IsDefaultVersion",
-    "/properties/Schema",
-    "/properties/ProvisioningType",
-    "/properties/Visibility",
-    "/properties/SourceUrl",
     "/properties/DocumentationUrl",
+    "/properties/IsDefaultVersion",
     "/properties/LastUpdated",
+    "/properties/ProvisioningType",
+    "/properties/Schema",
+    "/properties/SourceUrl",
     "/properties/TimeCreated",
-    "/properties/VersionId"
+    "/properties/VersionId",
+    "/properties/Visibility"
   ],
-  "writeOnlyProperties": [
-    "/properties/SchemaHandlerPackage"
+  "createOnlyProperties": [
+    "/properties/ExecutionRoleArn",
+    "/properties/LoggingConfig",
+    "/properties/SchemaHandlerPackage",
+    "/properties/TypeName"
   ],
   "primaryIdentifier": [
     "/properties/Arn"


### PR DESCRIPTION
*Description of changes:*

Every registration of a CloudFormation Resource Provider creates a new version, which is identified by a version-specific ARN. This means there isn't technically an "update" of a resource provider; each registration is a new distinct resource. This was accounted for by excluding an `UpdateHandler` for this `AWS::CloudFormation::ResourceVersion` resource provider.

The schema for this resource provider does not define any `createOnlyProperties`. Therefore, any attempt to use this resource provider to register another resource provider would only work during the `CREATE`; any attempt to `UPDATE` the resource (e.g. changing `SchemaHandlerPackage` to an updated source package) would try to update the resource rather than triggering a replacement, which would fail due to the lack of an `UpdateHandler` (the resource would enter the `UPDATE_FAILED` state with a message of "Internal Failure", and no logs would be present in CloudWatch Logs).

Since changing any of the writable `Properties` of this resource provider results in a new physical resource (identified in the resource provider as the versioned `Arn`), all of these properties must be `createOnlyProperties` to force a replacement rather than an update. In essence, this resource is logically very similar to `AWS::ECS::TaskDefinition` - both resources use a versioned identifier, and any change results in a new version. Any change to a `TaskDefinition` results in resource replacement, followed by unregistration of the previous version during stack cleanup. This PR results in `AWS::CloudFormation::ResourceVersion` logically behaving the same.

One caveat is that `AWS::CloudFormation::ResourceVersion` really needs to be used in tandem with the `AWS::CloudFormation::ResourceDefaultVersion` resource to automatically update the default version. Otherwise, if a created `ResourceVersion` is the default version for that type (e.g. the `CREATE` was the first registration of a new/deleted resource type, or `SetTypeDefaultVersion` was used externally), an update will fail to delete the previous resource during the stack cleanup stage, resulting in an error of `This type has more than one active version. Please deregister non-default active versions before attempting to deregister the type.`.

I also re-ordered the `readOnlyProperties` to be alphabetical, which matches the order in which they are defined in `/properties`.
