### PR TITLE
Configure timeout for UpdateStackSets and Add Loggings

### DIFF
--- a/aws-cloudformation-stackset/src/main/java/software/amazon/cloudformation/stackset/BaseHandlerStd.java
+++ b/aws-cloudformation-stackset/src/main/java/software/amazon/cloudformation/stackset/BaseHandlerStd.java
@@ -138,7 +138,7 @@ public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
                     .backoffDelay(MULTIPLE_OF)
                     .makeServiceCall((modelRequest, proxyInvocation) -> {
                         final CreateStackInstancesResponse response = proxyInvocation.injectCredentialsAndInvokeV2(modelRequest, proxyInvocation.client()::createStackInstances);
-                        logger.log(String.format("%s CreateStackInstances in [%s] of [%s] initiated", ResourceModel.TYPE_NAME, stackInstances.getRegions(), stackInstances.getDeploymentTargets()));
+                        logger.log(String.format("%s [%s] CreateStackInstances in [%s] of [%s] initiated", ResourceModel.TYPE_NAME, model.getStackSetId(), stackInstances.getRegions(), stackInstances.getDeploymentTargets()));
                         return response;
                     })
                     .stabilize((request, response, proxyInvocation, resourceModel, context) -> isOperationStabilized(proxyInvocation, resourceModel, response.operationId(), logger))
@@ -180,7 +180,7 @@ public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
                     .backoffDelay(MULTIPLE_OF)
                     .makeServiceCall((modelRequest, proxyInvocation) -> {
                         final DeleteStackInstancesResponse response = proxyInvocation.injectCredentialsAndInvokeV2(modelRequest, proxyInvocation.client()::deleteStackInstances);
-                        logger.log(String.format("%s DeleteStackInstances in [%s] of [%s] initiated", ResourceModel.TYPE_NAME, stackInstances.getRegions(), stackInstances.getDeploymentTargets()));
+                        logger.log(String.format("%s [%s] DeleteStackInstances in [%s] of [%s] initiated", ResourceModel.TYPE_NAME, model.getStackSetId(), stackInstances.getRegions(), stackInstances.getDeploymentTargets()));
                         return response;
                     })
                     .stabilize((request, response, proxyInvocation, resourceModel, context) -> isOperationStabilized(proxyInvocation, resourceModel, response.operationId(), logger))
@@ -233,7 +233,7 @@ public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
                     .backoffDelay(MULTIPLE_OF)
                     .makeServiceCall((modelRequest, proxyInvocation) -> {
                         final UpdateStackInstancesResponse response = proxyInvocation.injectCredentialsAndInvokeV2(modelRequest, proxyInvocation.client()::updateStackInstances);
-                        logger.log(String.format("%s UpdateStackInstances in [%s] of [%s] initiated", ResourceModel.TYPE_NAME, stackInstances.getRegions(), stackInstances.getDeploymentTargets()));
+                        logger.log(String.format("%s [%s] UpdateStackInstances in [%s] of [%s] initiated", ResourceModel.TYPE_NAME, model.getStackSetId(), stackInstances.getRegions(), stackInstances.getDeploymentTargets()));
                         return response;
                     })
                     .stabilize((request, response, proxyInvocation, resourceModel, context) -> isOperationStabilized(proxyInvocation, resourceModel, response.operationId(), logger))

--- a/aws-cloudformation-stackset/src/main/java/software/amazon/cloudformation/stackset/UpdateHandler.java
+++ b/aws-cloudformation-stackset/src/main/java/software/amazon/cloudformation/stackset/UpdateHandler.java
@@ -63,9 +63,10 @@ public class UpdateHandler extends BaseHandlerStd {
         }
         return proxy.initiate("AWS-CloudFormation-StackSet::UpdateStackSet", client, desiredModel, callbackContext)
                 .translateToServiceRequest(modelRequest -> updateStackSetRequest(modelRequest))
+                .backoffDelay(MULTIPLE_OF)
                 .makeServiceCall((modelRequest, proxyInvocation) -> {
                     final UpdateStackSetResponse response = proxyInvocation.injectCredentialsAndInvokeV2(modelRequest, proxyInvocation.client()::updateStackSet);
-                    logger.log(String.format("%s UpdateStackSet initiated", ResourceModel.TYPE_NAME));
+                    logger.log(String.format("%s [%s] UpdateStackSet initiated", ResourceModel.TYPE_NAME, previousModel.getStackSetId()));
                     return response;
                 })
                 .stabilize((request, response, proxyInvocation, resourceModel, context) -> isOperationStabilized(proxyInvocation, resourceModel, response.operationId(), logger))


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
* Configure timeout for UpdateStackSets to fix the bug that when UpdateStackSet operation takes long time causing timeout exception
* Add more logs for debugging



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
