### PR TITLE
StackSets Takes StackTags and Retry Strategy When Throttling

### DIFF
--- a/aws-cloudformation-stackset/src/main/java/software/amazon/cloudformation/stackset/Configuration.java
+++ b/aws-cloudformation-stackset/src/main/java/software/amazon/cloudformation/stackset/Configuration.java
@@ -1,8 +1,28 @@
 package software.amazon.cloudformation.stackset;
 
+import org.json.JSONObject;
+import org.json.JSONTokener;
+import software.amazon.awssdk.utils.CollectionUtils;
+
+import java.util.Map;
+import java.util.stream.Collectors;
+
 class Configuration extends BaseConfiguration {
 
     public Configuration() {
         super("aws-cloudformation-stackset.json");
+    }
+
+    public JSONObject resourceSchemaJsonObject() {
+        return new JSONObject(
+                new JSONTokener(this.getClass().getClassLoader().getResourceAsStream(schemaFilename)));
+    }
+
+    public Map<String, String> resourceDefinedTags(final ResourceModel resourceModel) {
+        if (CollectionUtils.isNullOrEmpty(resourceModel.getTags())) return null;
+
+        return resourceModel.getTags()
+                .stream()
+                .collect(Collectors.toMap(Tag::getKey, Tag::getValue, (value1, value2) -> value2));
     }
 }

--- a/aws-cloudformation-stackset/src/main/java/software/amazon/cloudformation/stackset/Configuration.java
+++ b/aws-cloudformation-stackset/src/main/java/software/amazon/cloudformation/stackset/Configuration.java
@@ -23,6 +23,6 @@ class Configuration extends BaseConfiguration {
 
         return resourceModel.getTags()
                 .stream()
-                .collect(Collectors.toMap(Tag::getKey, Tag::getValue, (value1, value2) -> value2));
+                .collect(Collectors.toMap(Tag::getKey, Tag::getValue));
     }
 }

--- a/aws-cloudformation-stackset/src/main/java/software/amazon/cloudformation/stackset/CreateHandler.java
+++ b/aws-cloudformation-stackset/src/main/java/software/amazon/cloudformation/stackset/CreateHandler.java
@@ -38,6 +38,6 @@ public class CreateHandler extends BaseHandlerStd {
                 })
                 .progress()
                 .then(progress -> createStackInstances(proxy, proxyClient, progress, placeHolder.getCreateStackInstances(), logger))
-                .then(progress -> new ReadHandler().handleRequest(proxy, request, callbackContext, proxyClient, logger));
+                .then(progress -> ProgressEvent.defaultSuccessHandler(model));
     }
 }

--- a/aws-cloudformation-stackset/src/main/java/software/amazon/cloudformation/stackset/CreateHandler.java
+++ b/aws-cloudformation-stackset/src/main/java/software/amazon/cloudformation/stackset/CreateHandler.java
@@ -29,7 +29,7 @@ public class CreateHandler extends BaseHandlerStd {
         analyzeTemplate(proxyClient, request, placeHolder, Action.CREATE);
 
         return proxy.initiate("AWS-CloudFormation-StackSet::Create", proxyClient, model, callbackContext)
-                .translateToServiceRequest(resourceModel -> createStackSetRequest(resourceModel, request.getClientRequestToken()))
+                .translateToServiceRequest(resourceModel -> createStackSetRequest(resourceModel, request.getClientRequestToken(), request.getDesiredResourceTags()))
                 .makeServiceCall((modelRequest, proxyInvocation) -> {
                     final CreateStackSetResponse response = proxyClient.injectCredentialsAndInvokeV2(modelRequest, proxyClient.client()::createStackSet);
                     model.setStackSetId(response.stackSetId());

--- a/aws-cloudformation-stackset/src/main/java/software/amazon/cloudformation/stackset/UpdateHandler.java
+++ b/aws-cloudformation-stackset/src/main/java/software/amazon/cloudformation/stackset/UpdateHandler.java
@@ -36,7 +36,7 @@ public class UpdateHandler extends BaseHandlerStd {
                 .then(progress -> updateStackSet(proxy, proxyClient, request, progress, previousModel))
                 .then(progress -> createStackInstances(proxy, proxyClient, progress, placeHolder.getCreateStackInstances(), logger))
                 .then(progress -> updateStackInstances(proxy, proxyClient, progress, placeHolder.getUpdateStackInstances(), logger))
-                .then(progress -> new ReadHandler().handleRequest(proxy, request, callbackContext, proxyClient, logger));
+                .then(progress -> ProgressEvent.defaultSuccessHandler(model));
     }
 
     /**

--- a/aws-cloudformation-stackset/src/main/java/software/amazon/cloudformation/stackset/translator/PropertyTranslator.java
+++ b/aws-cloudformation-stackset/src/main/java/software/amazon/cloudformation/stackset/translator/PropertyTranslator.java
@@ -13,6 +13,8 @@ import software.amazon.cloudformation.stackset.util.StackInstance;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -122,14 +124,14 @@ public class PropertyTranslator {
      * @param tags Tags CFN resource model.
      * @return SDK Tags.
      */
-    static List<Tag> translateToSdkTags(final Collection<software.amazon.cloudformation.stackset.Tag> tags) {
-        // To remove Tags from a StackSet, set it as an empty list
-        if (CollectionUtils.isNullOrEmpty(tags)) return Collections.emptyList();
-        return tags.stream().map(tag -> Tag.builder()
-                .key(tag.getKey())
-                .value(tag.getValue())
-                .build())
-                .collect(Collectors.toList());
+    public static Set<Tag> translateToSdkTags(final Map<String, String> tags) {
+        if (tags == null) {
+            return Collections.emptySet();
+        }
+        return Optional.of(tags.entrySet()).orElse(Collections.emptySet())
+                .stream()
+                .map(tag -> Tag.builder().key(tag.getKey()).value(tag.getValue()).build())
+                .collect(Collectors.toSet());
     }
 
     /**

--- a/aws-cloudformation-stackset/src/main/java/software/amazon/cloudformation/stackset/translator/RequestTranslator.java
+++ b/aws-cloudformation-stackset/src/main/java/software/amazon/cloudformation/stackset/translator/RequestTranslator.java
@@ -16,6 +16,8 @@ import software.amazon.cloudformation.stackset.OperationPreferences;
 import software.amazon.cloudformation.stackset.ResourceModel;
 import software.amazon.cloudformation.stackset.StackInstances;
 
+import java.util.Map;
+
 import static software.amazon.cloudformation.stackset.translator.PropertyTranslator.translateToSdkAutoDeployment;
 import static software.amazon.cloudformation.stackset.translator.PropertyTranslator.translateToSdkDeploymentTargets;
 import static software.amazon.cloudformation.stackset.translator.PropertyTranslator.translateToSdkOperationPreferences;
@@ -27,7 +29,7 @@ public class RequestTranslator {
     private static final int LIST_MAX_ITEMS = 100;
 
     public static CreateStackSetRequest createStackSetRequest(
-            final ResourceModel model, final String requestToken) {
+            final ResourceModel model, final String requestToken, final Map<String, String> tags) {
         return CreateStackSetRequest.builder()
                 .stackSetName(model.getStackSetName())
                 .administrationRoleARN(model.getAdministrationRoleARN())
@@ -38,7 +40,7 @@ public class RequestTranslator {
                 .description(model.getDescription())
                 .executionRoleName(model.getExecutionRoleName())
                 .parameters(translateToSdkParameters(model.getParameters()))
-                .tags(translateToSdkTags(model.getTags()))
+                .tags(translateToSdkTags(tags))
                 .templateBody(model.getTemplateBody())
                 .templateURL(model.getTemplateURL())
                 .build();
@@ -88,7 +90,7 @@ public class RequestTranslator {
                 .build();
     }
 
-    public static UpdateStackSetRequest updateStackSetRequest(final ResourceModel model) {
+    public static UpdateStackSetRequest updateStackSetRequest(final ResourceModel model, final Map<String, String> tags) {
         return UpdateStackSetRequest.builder()
                 .stackSetName(model.getStackSetId())
                 .administrationRoleARN(model.getAdministrationRoleARN())
@@ -99,7 +101,7 @@ public class RequestTranslator {
                 .parameters(translateToSdkParameters(model.getParameters()))
                 .templateURL(model.getTemplateURL())
                 .templateBody(model.getTemplateBody())
-                .tags(translateToSdkTags(model.getTags()))
+                .tags(translateToSdkTags(tags))
                 .build();
     }
 

--- a/aws-cloudformation-stackset/src/main/java/software/amazon/cloudformation/stackset/util/ClientBuilder.java
+++ b/aws-cloudformation-stackset/src/main/java/software/amazon/cloudformation/stackset/util/ClientBuilder.java
@@ -1,5 +1,15 @@
 package software.amazon.cloudformation.stackset.util;
 
+import com.amazonaws.util.StringUtils;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+import software.amazon.awssdk.core.client.config.ClientOverrideConfiguration;
+import software.amazon.awssdk.core.retry.RetryPolicy;
+import software.amazon.awssdk.core.retry.RetryPolicyContext;
+import software.amazon.awssdk.core.retry.backoff.BackoffStrategy;
+import software.amazon.awssdk.core.retry.conditions.OrRetryCondition;
+import software.amazon.awssdk.core.retry.conditions.RetryCondition;
 import software.amazon.awssdk.services.cloudformation.CloudFormationClient;
 import software.amazon.cloudformation.LambdaWrapper;
 
@@ -18,8 +28,45 @@ public class ClientBuilder {
      * @return {@link CloudFormationClient}
      */
     private static class LazyHolder {
+
+        private static final Integer MAX_RETRIES = 5;
+
         public static CloudFormationClient SERVICE_CLIENT = CloudFormationClient.builder()
                 .httpClient(LambdaWrapper.HTTP_CLIENT)
+                .overrideConfiguration(ClientOverrideConfiguration.builder()
+                        .retryPolicy(RetryPolicy.builder()
+                                .backoffStrategy(BackoffStrategy.defaultThrottlingStrategy())
+                                .throttlingBackoffStrategy(BackoffStrategy.defaultThrottlingStrategy())
+                                .numRetries(MAX_RETRIES)
+                                .retryCondition(OrRetryCondition.create(new RetryCondition[]{
+                                        RetryCondition.defaultRetryCondition(),
+                                        CloudFormationRetryCondition.create()
+                                }))
+                                .build())
+                        .build())
                 .build();
     }
+
+    /**
+     * CloudFormation Throttling Exception StatusCode is 400 while default throttling code is 429
+     * https://github.com/aws/aws-sdk-java-v2/blob/master/core/sdk-core/src/main/java/software/amazon/awssdk/core/exception/SdkServiceException.java#L91
+     * which means we would need to customize a RetryCondition
+     */
+    @ToString
+    @EqualsAndHashCode
+    @NoArgsConstructor
+    public static class CloudFormationRetryCondition implements RetryCondition {
+
+        public static CloudFormationRetryCondition create() {
+            return new CloudFormationRetryCondition();
+        }
+
+        @Override
+        public boolean shouldRetry(RetryPolicyContext context) {
+            final String errorMessage = context.exception().getMessage();
+            if (StringUtils.isNullOrEmpty(errorMessage)) return false;
+            return errorMessage.contains("Rate exceeded");
+        }
+    }
+
 }

--- a/aws-cloudformation-stackset/src/main/java/software/amazon/cloudformation/stackset/util/Comparator.java
+++ b/aws-cloudformation-stackset/src/main/java/software/amazon/cloudformation/stackset/util/Comparator.java
@@ -5,6 +5,7 @@ import software.amazon.awssdk.services.cloudformation.model.PermissionModels;
 import software.amazon.cloudformation.stackset.ResourceModel;
 
 import java.util.Collection;
+import java.util.Map;
 
 /**
  * Utility class to help comparing previous model and desire model
@@ -17,12 +18,16 @@ public class Comparator {
      *
      * @param previousModel previous {@link ResourceModel}
      * @param desiredModel  desired {@link ResourceModel}
+     * @param previousTags  previous resource and stack tags
+     * @param desiredTags   desired resource and stack tags
      * @return
      */
-    public static boolean isStackSetConfigEquals(
-            final ResourceModel previousModel, final ResourceModel desiredModel) {
+    public static boolean isStackSetConfigEquals(final ResourceModel previousModel,
+                                                 final ResourceModel desiredModel,
+                                                 final Map<String, String> previousTags,
+                                                 final Map<String, String> desiredTags) {
 
-        if (!equals(previousModel.getTags(), desiredModel.getTags()))
+        if (!equals(previousTags, desiredTags))
             return false;
 
         if (StringUtils.compare(previousModel.getAdministrationRoleARN(),
@@ -55,6 +60,23 @@ public class Comparator {
             equals = collection1.size() == collection2.size()
                     && collection1.containsAll(collection2) && collection2.containsAll(collection1);
         } else if (collection1 == null && collection2 == null) {
+            equals = true;
+        }
+        return equals;
+    }
+
+    /**
+     * Compares if two maps equal in a null-safe way.
+     *
+     * @param map1
+     * @param map2
+     * @return boolean indicates if two maps equal.
+     */
+    public static boolean equals(final Map<?, ?> map1, final Map<?, ?> map2) {
+        boolean equals = false;
+        if (map1 != null && map2 != null) {
+            equals = map1.equals(map2);
+        } else if (map1 == null && map2 == null) {
             equals = true;
         }
         return equals;

--- a/aws-cloudformation-stackset/src/test/java/software/amazon/cloudformation/stackset/UpdateHandlerTest.java
+++ b/aws-cloudformation-stackset/src/test/java/software/amazon/cloudformation/stackset/UpdateHandlerTest.java
@@ -8,11 +8,8 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import software.amazon.awssdk.services.cloudformation.CloudFormationClient;
 import software.amazon.awssdk.services.cloudformation.model.CreateStackInstancesRequest;
 import software.amazon.awssdk.services.cloudformation.model.DeleteStackInstancesRequest;
-import software.amazon.awssdk.services.cloudformation.model.DescribeStackInstanceRequest;
 import software.amazon.awssdk.services.cloudformation.model.DescribeStackSetOperationRequest;
-import software.amazon.awssdk.services.cloudformation.model.DescribeStackSetRequest;
 import software.amazon.awssdk.services.cloudformation.model.GetTemplateSummaryRequest;
-import software.amazon.awssdk.services.cloudformation.model.ListStackInstancesRequest;
 import software.amazon.awssdk.services.cloudformation.model.UpdateStackInstancesRequest;
 import software.amazon.awssdk.services.cloudformation.model.UpdateStackSetRequest;
 import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
@@ -31,15 +28,10 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static software.amazon.cloudformation.stackset.util.TestUtils.CREATE_STACK_INSTANCES_RESPONSE;
 import static software.amazon.cloudformation.stackset.util.TestUtils.DELETE_STACK_INSTANCES_RESPONSE;
-import static software.amazon.cloudformation.stackset.util.TestUtils.DESCRIBE_SELF_MANAGED_STACK_SET_RESPONSE;
-import static software.amazon.cloudformation.stackset.util.TestUtils.DESCRIBE_STACK_INSTANCE_RESPONSE_1;
-import static software.amazon.cloudformation.stackset.util.TestUtils.DESCRIBE_STACK_INSTANCE_RESPONSE_2;
-import static software.amazon.cloudformation.stackset.util.TestUtils.DESCRIBE_STACK_INSTANCE_RESPONSE_3;
-import static software.amazon.cloudformation.stackset.util.TestUtils.DESCRIBE_STACK_INSTANCE_RESPONSE_4;
-import static software.amazon.cloudformation.stackset.util.TestUtils.LIST_SELF_MANAGED_STACK_SET_RESPONSE;
+import static software.amazon.cloudformation.stackset.util.TestUtils.DESIRED_RESOURCE_TAGS;
 import static software.amazon.cloudformation.stackset.util.TestUtils.OPERATION_SUCCEED_RESPONSE;
+import static software.amazon.cloudformation.stackset.util.TestUtils.PREVIOUS_RESOURCE_TAGS;
 import static software.amazon.cloudformation.stackset.util.TestUtils.SELF_MANAGED_MODEL;
-import static software.amazon.cloudformation.stackset.util.TestUtils.SELF_MANAGED_MODEL_FOR_READ;
 import static software.amazon.cloudformation.stackset.util.TestUtils.SIMPLE_MODEL;
 import static software.amazon.cloudformation.stackset.util.TestUtils.UPDATED_SELF_MANAGED_MODEL;
 import static software.amazon.cloudformation.stackset.util.TestUtils.UPDATE_STACK_INSTANCES_RESPONSE;
@@ -70,8 +62,10 @@ public class UpdateHandlerTest extends AbstractTestBase {
     public void handleRequest_SelfManagedSS_SimpleSuccess() {
 
         request = ResourceHandlerRequest.<ResourceModel>builder()
-                .desiredResourceState(UPDATED_SELF_MANAGED_MODEL)
                 .previousResourceState(SELF_MANAGED_MODEL)
+                .desiredResourceState(UPDATED_SELF_MANAGED_MODEL)
+                .previousResourceTags(PREVIOUS_RESOURCE_TAGS)
+                .desiredResourceTags(DESIRED_RESOURCE_TAGS)
                 .build();
 
         when(proxyClient.client().getTemplateSummary(any(GetTemplateSummaryRequest.class)))
@@ -86,15 +80,6 @@ public class UpdateHandlerTest extends AbstractTestBase {
                 .thenReturn(UPDATE_STACK_INSTANCES_RESPONSE);
         when(proxyClient.client().describeStackSetOperation(any(DescribeStackSetOperationRequest.class)))
                 .thenReturn(OPERATION_SUCCEED_RESPONSE);
-        when(proxyClient.client().describeStackSet(any(DescribeStackSetRequest.class)))
-                .thenReturn(DESCRIBE_SELF_MANAGED_STACK_SET_RESPONSE);
-        when(proxyClient.client().listStackInstances(any(ListStackInstancesRequest.class)))
-                .thenReturn(LIST_SELF_MANAGED_STACK_SET_RESPONSE);
-        when(proxyClient.client().describeStackInstance(any(DescribeStackInstanceRequest.class)))
-                .thenReturn(DESCRIBE_STACK_INSTANCE_RESPONSE_1,
-                        DESCRIBE_STACK_INSTANCE_RESPONSE_2,
-                        DESCRIBE_STACK_INSTANCE_RESPONSE_3,
-                        DESCRIBE_STACK_INSTANCE_RESPONSE_4);
 
         final ProgressEvent<ResourceModel, CallbackContext> response
                 = handler.handleRequest(proxy, request, new CallbackContext(), proxyClient, logger);
@@ -103,7 +88,7 @@ public class UpdateHandlerTest extends AbstractTestBase {
         assertThat(response.getStatus()).isEqualTo(OperationStatus.SUCCESS);
         assertThat(response.getCallbackContext()).isNull();
         assertThat(response.getCallbackDelaySeconds()).isEqualTo(0);
-        assertThat(response.getResourceModel()).isEqualTo(SELF_MANAGED_MODEL_FOR_READ);
+        assertThat(response.getResourceModel()).isEqualTo(UPDATED_SELF_MANAGED_MODEL);
         assertThat(response.getMessage()).isNull();
         assertThat(response.getErrorCode()).isNull();
 
@@ -113,30 +98,20 @@ public class UpdateHandlerTest extends AbstractTestBase {
         verify(proxyClient.client()).updateStackInstances(any(UpdateStackInstancesRequest.class));
         verify(proxyClient.client()).deleteStackInstances(any(DeleteStackInstancesRequest.class));
         verify(proxyClient.client(), times(4)).describeStackSetOperation(any(DescribeStackSetOperationRequest.class));
-        verify(proxyClient.client()).describeStackSet(any(DescribeStackSetRequest.class));
-        verify(proxyClient.client()).listStackInstances(any(ListStackInstancesRequest.class));
-        verify(proxyClient.client(), times(4)).describeStackInstance(any(DescribeStackInstanceRequest.class));
     }
 
     @Test
     public void handleRequest_NotUpdatable_Success() {
 
         request = ResourceHandlerRequest.<ResourceModel>builder()
-                .desiredResourceState(SIMPLE_MODEL)
                 .previousResourceState(SIMPLE_MODEL)
+                .desiredResourceState(SIMPLE_MODEL)
+                .previousResourceTags(DESIRED_RESOURCE_TAGS)
+                .desiredResourceTags(DESIRED_RESOURCE_TAGS)
                 .build();
 
         when(proxyClient.client().getTemplateSummary(any(GetTemplateSummaryRequest.class)))
                 .thenReturn(VALID_TEMPLATE_SUMMARY_RESPONSE);
-        when(proxyClient.client().describeStackSet(any(DescribeStackSetRequest.class)))
-                .thenReturn(DESCRIBE_SELF_MANAGED_STACK_SET_RESPONSE);
-        when(proxyClient.client().listStackInstances(any(ListStackInstancesRequest.class)))
-                .thenReturn(LIST_SELF_MANAGED_STACK_SET_RESPONSE);
-        when(proxyClient.client().describeStackInstance(any(DescribeStackInstanceRequest.class)))
-                .thenReturn(DESCRIBE_STACK_INSTANCE_RESPONSE_1,
-                        DESCRIBE_STACK_INSTANCE_RESPONSE_2,
-                        DESCRIBE_STACK_INSTANCE_RESPONSE_3,
-                        DESCRIBE_STACK_INSTANCE_RESPONSE_4);
 
         final ProgressEvent<ResourceModel, CallbackContext> response
                 = handler.handleRequest(proxy, request, new CallbackContext(), proxyClient, logger);
@@ -145,14 +120,11 @@ public class UpdateHandlerTest extends AbstractTestBase {
         assertThat(response.getStatus()).isEqualTo(OperationStatus.SUCCESS);
         assertThat(response.getCallbackContext()).isNull();
         assertThat(response.getCallbackDelaySeconds()).isEqualTo(0);
-        assertThat(response.getResourceModel()).isEqualTo(SELF_MANAGED_MODEL_FOR_READ);
+        assertThat(response.getResourceModel()).isEqualTo(SIMPLE_MODEL);
         assertThat(response.getResourceModels()).isNull();
         assertThat(response.getMessage()).isNull();
         assertThat(response.getErrorCode()).isNull();
 
         verify(proxyClient.client()).getTemplateSummary(any(GetTemplateSummaryRequest.class));
-        verify(proxyClient.client()).describeStackSet(any(DescribeStackSetRequest.class));
-        verify(proxyClient.client()).listStackInstances(any(ListStackInstancesRequest.class));
-        verify(proxyClient.client(), times(4)).describeStackInstance(any(DescribeStackInstanceRequest.class));
     }
 }

--- a/aws-cloudformation-stackset/src/test/java/software/amazon/cloudformation/stackset/util/ClientBuilderTest.java
+++ b/aws-cloudformation-stackset/src/test/java/software/amazon/cloudformation/stackset/util/ClientBuilderTest.java
@@ -1,0 +1,21 @@
+package software.amazon.cloudformation.stackset.util;
+
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.awscore.exception.AwsServiceException;
+import software.amazon.awssdk.core.retry.RetryPolicyContext;
+import software.amazon.awssdk.services.cloudformation.model.CloudFormationException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ClientBuilderTest {
+
+    @Test
+    public void testCloudFormationRetryConditionRetryOnCloudFormationThrottlingException() {
+        final AwsServiceException exception = CloudFormationException.builder()
+                .message("Rate exceeded")
+                .statusCode(400)
+                .build();
+        final RetryPolicyContext retryPolicyContext = RetryPolicyContext.builder().exception(exception).build();
+        assertThat(new ClientBuilder.CloudFormationRetryCondition().shouldRetry(retryPolicyContext)).isTrue();
+    }
+}

--- a/aws-cloudformation-stackset/src/test/java/software/amazon/cloudformation/stackset/util/ComparatorTest.java
+++ b/aws-cloudformation-stackset/src/test/java/software/amazon/cloudformation/stackset/util/ComparatorTest.java
@@ -7,7 +7,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static software.amazon.cloudformation.stackset.util.Comparator.isStackSetConfigEquals;
 import static software.amazon.cloudformation.stackset.util.TestUtils.ADMINISTRATION_ROLE_ARN;
 import static software.amazon.cloudformation.stackset.util.TestUtils.DESCRIPTION;
+import static software.amazon.cloudformation.stackset.util.TestUtils.DESIRED_RESOURCE_TAGS;
 import static software.amazon.cloudformation.stackset.util.TestUtils.EXECUTION_ROLE_NAME;
+import static software.amazon.cloudformation.stackset.util.TestUtils.PREVIOUS_RESOURCE_TAGS;
 import static software.amazon.cloudformation.stackset.util.TestUtils.TAGS;
 import static software.amazon.cloudformation.stackset.util.TestUtils.TAGS_TO_UPDATE;
 import static software.amazon.cloudformation.stackset.util.TestUtils.TEMPLATE_BODY;
@@ -23,53 +25,52 @@ public class ComparatorTest {
     @Test
     public void testIsStackSetConfigEquals() {
 
-        final ResourceModel testPreviousModel = ResourceModel.builder().tags(TAGS).build();
-        final ResourceModel testDesiredModel = ResourceModel.builder().tags(TAGS_TO_UPDATE).build();
+        final ResourceModel testPreviousModel = ResourceModel.builder().build();
+        final ResourceModel testDesiredModel = ResourceModel.builder().build();
 
-        assertThat(isStackSetConfigEquals(testPreviousModel, testDesiredModel)).isFalse();
+        assertThat(isStackSetConfigEquals(testPreviousModel, testDesiredModel, PREVIOUS_RESOURCE_TAGS, DESIRED_RESOURCE_TAGS)).isFalse();
 
-        testDesiredModel.setTags(TAGS);
         testDesiredModel.setAdministrationRoleARN(UPDATED_ADMINISTRATION_ROLE_ARN);
         testPreviousModel.setAdministrationRoleARN(ADMINISTRATION_ROLE_ARN);
 
-        assertThat(isStackSetConfigEquals(testPreviousModel, testDesiredModel)).isFalse();
+        assertThat(isStackSetConfigEquals(testPreviousModel, testDesiredModel, DESIRED_RESOURCE_TAGS, DESIRED_RESOURCE_TAGS)).isFalse();
 
         testDesiredModel.setAdministrationRoleARN(ADMINISTRATION_ROLE_ARN);
         testDesiredModel.setDescription(UPDATED_DESCRIPTION);
         testPreviousModel.setDescription(DESCRIPTION);
 
-        assertThat(isStackSetConfigEquals(testPreviousModel, testDesiredModel)).isFalse();
+        assertThat(isStackSetConfigEquals(testPreviousModel, testDesiredModel, DESIRED_RESOURCE_TAGS, DESIRED_RESOURCE_TAGS)).isFalse();
 
         testDesiredModel.setDescription(DESCRIPTION);
         testDesiredModel.setExecutionRoleName(UPDATED_EXECUTION_ROLE_NAME);
         testPreviousModel.setExecutionRoleName(EXECUTION_ROLE_NAME);
 
-        assertThat(isStackSetConfigEquals(testPreviousModel, testDesiredModel)).isFalse();
+        assertThat(isStackSetConfigEquals(testPreviousModel, testDesiredModel, DESIRED_RESOURCE_TAGS, DESIRED_RESOURCE_TAGS)).isFalse();
 
         testDesiredModel.setExecutionRoleName(EXECUTION_ROLE_NAME);
         testDesiredModel.setTemplateURL(UPDATED_TEMPLATE_URL);
         testPreviousModel.setTemplateURL(TEMPLATE_URL);
 
-        assertThat(isStackSetConfigEquals(testPreviousModel, testDesiredModel)).isFalse();
+        assertThat(isStackSetConfigEquals(testPreviousModel, testDesiredModel, DESIRED_RESOURCE_TAGS, DESIRED_RESOURCE_TAGS)).isFalse();
 
         // Even if both TemplateURLs remain no change, we still need to call Update API
         // The service client will decide if it needs to update
         testDesiredModel.setTemplateURL(TEMPLATE_URL);
         testPreviousModel.setTemplateURL(TEMPLATE_URL);
-        assertThat(isStackSetConfigEquals(testPreviousModel, testDesiredModel)).isFalse();
+        assertThat(isStackSetConfigEquals(testPreviousModel, testDesiredModel, DESIRED_RESOURCE_TAGS, DESIRED_RESOURCE_TAGS)).isFalse();
 
         // previously using TemplateURL, currently using TemplateBody
         testPreviousModel.setTemplateURL(TEMPLATE_URL);
         testDesiredModel.setTemplateURL(null);
         testDesiredModel.setTemplateBody(TEMPLATE_BODY);
-        assertThat(isStackSetConfigEquals(testPreviousModel, testDesiredModel)).isFalse();
+        assertThat(isStackSetConfigEquals(testPreviousModel, testDesiredModel, DESIRED_RESOURCE_TAGS, DESIRED_RESOURCE_TAGS)).isFalse();
 
         // previously using TemplateBody, currently using TemplateURL
         testPreviousModel.setTemplateBody(TEMPLATE_URL);
         testPreviousModel.setTemplateURL(null);
         testDesiredModel.setTemplateBody(null);
         testDesiredModel.setTemplateURL(TEMPLATE_URL);
-        assertThat(isStackSetConfigEquals(testPreviousModel, testDesiredModel)).isFalse();
+        assertThat(isStackSetConfigEquals(testPreviousModel, testDesiredModel, DESIRED_RESOURCE_TAGS, DESIRED_RESOURCE_TAGS)).isFalse();
 
         // Both using TemplateBody
         testDesiredModel.setTemplateURL(null);
@@ -78,10 +79,10 @@ public class ComparatorTest {
         testDesiredModel.setTemplateBody(UPDATED_TEMPLATE_BODY);
         testPreviousModel.setTemplateBody(TEMPLATE_BODY);
 
-        assertThat(isStackSetConfigEquals(testPreviousModel, testDesiredModel)).isFalse();
+        assertThat(isStackSetConfigEquals(testPreviousModel, testDesiredModel, DESIRED_RESOURCE_TAGS, DESIRED_RESOURCE_TAGS)).isFalse();
 
         testDesiredModel.setTemplateBody(TEMPLATE_BODY);
-        assertThat(isStackSetConfigEquals(testPreviousModel, testDesiredModel)).isTrue();
+        assertThat(isStackSetConfigEquals(testPreviousModel, testDesiredModel, DESIRED_RESOURCE_TAGS, DESIRED_RESOURCE_TAGS)).isTrue();
 
     }
 
@@ -89,6 +90,10 @@ public class ComparatorTest {
     public void testEquals() {
         assertThat(Comparator.equals(TAGS, null)).isFalse();
         assertThat(Comparator.equals(null, TAGS)).isFalse();
+        assertThat(Comparator.equals(TAGS, TAGS)).isTrue();
+        assertThat(Comparator.equals(TAGS, TAGS_TO_UPDATE)).isFalse();
+        assertThat(Comparator.equals(DESIRED_RESOURCE_TAGS, null)).isFalse();
+        assertThat(Comparator.equals(null, DESIRED_RESOURCE_TAGS)).isFalse();
     }
 
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

* StackSet handlers take stack tags
* Add retry strategy for CloudFormation client in StackSet

*Testing*

* Manual create/update stack with stack tags.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
