### PR TITLE
Setting ModuleVersion's ModulePackage field to "required"

### DIFF
--- a/aws-cloudformation-moduleversion/aws-cloudformation-moduleversion.json
+++ b/aws-cloudformation-moduleversion/aws-cloudformation-moduleversion.json
@@ -56,9 +56,11 @@
     }
   },
   "required": [
-    "ModuleName"
+    "ModuleName",
+    "ModulePackage"
   ],
   "createOnlyProperties": [
+    "/properties/ModuleName",
     "/properties/ModulePackage"
   ],
   "readOnlyProperties": [

--- a/aws-cloudformation-moduleversion/docs/README.md
+++ b/aws-cloudformation-moduleversion/docs/README.md
@@ -41,13 +41,13 @@ _Type_: String
 
 _Pattern_: <code>^[A-Za-z0-9]{2,64}::[A-Za-z0-9]{2,64}::[A-Za-z0-9]{2,64}::MODULE</code>
 
-_Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
+_Update requires_: [Replacement](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-replacement)
 
 #### ModulePackage
 
 The url to the S3 bucket containing the schema and template fragment for the module you want to register.
 
-_Required_: No
+_Required_: Yes
 
 _Type_: String
 

--- a/aws-cloudformation-moduleversion/overrides.json
+++ b/aws-cloudformation-moduleversion/overrides.json
@@ -1,6 +1,6 @@
 {
   "CREATE": {
-    "/Name": "Your::Personal::Test::MODULE",
+    "/ModuleName": "Your::Personal::Test::MODULE",
     "/ModulePackage": "s3://<your_s3_bucket_name>/<your_module_package_key>"
   }
 }

--- a/aws-cloudformation-moduleversion/src/main/java/software/amazon/cloudformation/moduleversion/CreateHandler.java
+++ b/aws-cloudformation-moduleversion/src/main/java/software/amazon/cloudformation/moduleversion/CreateHandler.java
@@ -125,14 +125,4 @@ public class CreateHandler extends BaseHandlerStd {
                 throw new CfnGeneralServiceException(String.format("received unexpected module registration status: %s", dtrResponse.progressStatus()));
         }
     }
-
-    @Override
-    protected void validateModel(final ResourceModel model) {
-        if (model == null) {
-            throw new CfnInvalidRequestException("ResourceModel is required");
-        }
-        if (model.getModulePackage() == null) {
-            throw new CfnInvalidRequestException("ModulePackage is required in ResourceModel");
-        }
-    }
 }


### PR DESCRIPTION
I had originally left `ModuleVersion`'s `ModulePackage` field out of the "required" fields in the schema because it was causing issues with contract tests (i.e. contract tests would fail when attempting a delete operation because the module package field was required, but cannot be read in `DescribeType` requests and supplied to the delete handler [#318](https://github.com/aws-cloudformation/cloudformation-cli-java-plugin/issues/318)). I had temporarily implemented manual validation in the `ModuleVersion` create handler to check for `ModulePackage` to compensate.

After building, running the unit tests, and testing these changes manually in my account through a number of create-, update-, and delete-stack operations, I am confident setting `ModulePackage` as "required" is safe, despite being flagged by the contract tests for the above reason. `ModulePackage` is not required as input to the delete handler -- only the ARN is.

With this change, the `AWS::CloudFormation::ModuleVersion` documentation will now agree with the schema as well.

I also added `ModuleName` to `createOnlyProperties`, as it should have been.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
