### PR TITLE
moving required AWS::CloudFormation::StackSet properties out of oneOf

### DIFF
--- a/aws-cloudformation-stackset/aws-cloudformation-stackset.json
+++ b/aws-cloudformation-stackset/aws-cloudformation-stackset.json
@@ -270,19 +270,19 @@
       "maxLength": 1024
     }
   },
+  "required": [
+    "StackSetName",
+    "PermissionModel"
+  ],
   "oneOf": [
     {
       "required": [
-        "TemplateURL",
-        "StackSetName",
-        "PermissionModel"
+        "TemplateURL"
       ]
     },
     {
       "required": [
-        "TemplateBody",
-        "StackSetName",
-        "PermissionModel"
+        "TemplateBody"
       ]
     }
   ],


### PR DESCRIPTION
https://json-schema.org/understanding-json-schema/reference/combining.html
https://github.com/aws-cloudformation/aws-cloudformation-resource-providers-cloudformation/issues/17

```bash
$ grep -l -E -i '(oneOf|anyOf|allOf)' * # other combined resource schemas to look into from https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/resource-type-schemas.html
aws-applicationinsights-application.json
a̶w̶s̶-̶c̶l̶o̶u̶d̶f̶o̶r̶m̶a̶t̶i̶o̶n̶-̶m̶o̶d̶u̶l̶e̶d̶e̶f̶a̶u̶l̶t̶v̶e̶r̶s̶i̶o̶n̶.̶j̶s̶o̶n̶
a̶w̶s̶-̶c̶l̶o̶u̶d̶f̶o̶r̶m̶a̶t̶i̶o̶n̶-̶s̶t̶a̶c̶k̶s̶e̶t̶.̶j̶s̶o̶n̶
aws-cloudwatch-metricstream.json
a̶w̶s̶-̶d̶a̶t̶a̶b̶r̶e̶w̶-̶d̶a̶t̶a̶s̶e̶t̶.̶j̶s̶o̶n̶
a̶w̶s̶-̶d̶a̶t̶a̶b̶r̶e̶w̶-̶r̶e̶c̶i̶p̶e̶.̶j̶s̶o̶n̶
a̶w̶s̶-̶g̶a̶m̶e̶l̶i̶f̶t̶-̶a̶l̶i̶a̶s̶.̶j̶s̶o̶n̶
a̶w̶s̶-̶k̶e̶n̶d̶r̶a̶-̶d̶a̶t̶a̶s̶o̶u̶r̶c̶e̶.̶j̶s̶o̶n̶
a̶w̶s̶-̶r̶d̶s̶-̶g̶l̶o̶b̶a̶l̶c̶l̶u̶s̶t̶e̶r̶.̶j̶s̶o̶n̶
a̶w̶s̶-̶s̶3̶-̶s̶t̶o̶r̶a̶g̶e̶l̶e̶n̶s̶.̶j̶s̶o̶n̶
a̶w̶s̶-̶s̶a̶g̶e̶m̶a̶k̶e̶r̶-̶p̶i̶p̶e̶l̶i̶n̶e̶.̶j̶s̶o̶n̶
a̶w̶s̶-̶s̶y̶n̶t̶h̶e̶t̶i̶c̶s̶-̶c̶a̶n̶a̶r̶y̶.̶j̶s̶o̶n̶
```