### PR TITLE
Fix StackSet Update - Only update Parameters/AutoDeployment

### DIFF
--- a/aws-cloudformation-stackset/src/main/java/software/amazon/cloudformation/stackset/util/Comparator.java
+++ b/aws-cloudformation-stackset/src/main/java/software/amazon/cloudformation/stackset/util/Comparator.java
@@ -43,6 +43,12 @@ public class Comparator {
         if (StringUtils.compare(previousModel.getTemplateBody(), desiredModel.getTemplateBody()) != 0)
             return false;
 
+        if (!equals(previousModel.getParameters(), desiredModel.getParameters()))
+            return false;
+
+        if (!equals(previousModel.getAutoDeployment(), desiredModel.getAutoDeployment()))
+            return false;
+
         // If TemplateURL is specified, always call Update API, Service client will decide if it is updatable
         return desiredModel.getTemplateURL() == null;
     }
@@ -66,17 +72,17 @@ public class Comparator {
     }
 
     /**
-     * Compares if two maps equal in a null-safe way.
+     * Compares if two objects equal in a null-safe way.
      *
-     * @param map1
-     * @param map2
-     * @return boolean indicates if two maps equal.
+     * @param object1
+     * @param object2
+     * @return boolean indicates if two objects equal.
      */
-    public static boolean equals(final Map<?, ?> map1, final Map<?, ?> map2) {
+    public static boolean equals(final Object object1, final Object object2) {
         boolean equals = false;
-        if (map1 != null && map2 != null) {
-            equals = map1.equals(map2);
-        } else if (map1 == null && map2 == null) {
+        if (object1 != null && object2 != null) {
+            equals = object1.equals(object2);
+        } else if (object1 == null && object2 == null) {
             equals = true;
         }
         return equals;

--- a/aws-cloudformation-stackset/src/test/java/software/amazon/cloudformation/stackset/util/TestUtils.java
+++ b/aws-cloudformation-stackset/src/test/java/software/amazon/cloudformation/stackset/util/TestUtils.java
@@ -1,8 +1,6 @@
 package software.amazon.cloudformation.stackset.util;
 
 import com.google.common.collect.ImmutableMap;
-import software.amazon.awssdk.awscore.exception.AwsServiceException;
-import software.amazon.awssdk.services.cloudformation.model.CloudFormationException;
 import software.amazon.awssdk.services.cloudformation.model.CreateStackInstancesResponse;
 import software.amazon.awssdk.services.cloudformation.model.CreateStackSetResponse;
 import software.amazon.awssdk.services.cloudformation.model.DeleteStackInstancesResponse;
@@ -124,6 +122,18 @@ public class TestUtils {
                     .parameterValue(PARAMETER_VALUE_1)
                     .build();
 
+    public final static software.amazon.cloudformation.stackset.Parameter PARAMETER_1_COPY =
+            software.amazon.cloudformation.stackset.Parameter.builder()
+                    .parameterKey(PARAMETER_KEY_1)
+                    .parameterValue(PARAMETER_VALUE_1)
+                    .build();
+
+    public final static software.amazon.cloudformation.stackset.Parameter PARAMETER_1_UPDATED =
+            software.amazon.cloudformation.stackset.Parameter.builder()
+                    .parameterKey(PARAMETER_KEY_1)
+                    .parameterValue(PARAMETER_VALUE_2)
+                    .build();
+
     public final static software.amazon.cloudformation.stackset.Parameter PARAMETER_2 =
             software.amazon.cloudformation.stackset.Parameter.builder()
                     .parameterKey(PARAMETER_KEY_2)
@@ -212,9 +222,19 @@ public class TestUtils {
             Tag.builder().key("key-2").value("val2").build(),
             Tag.builder().key("key-3").value("val3").build()));
 
-    public final static AutoDeployment AUTO_DEPLOYMENT = AutoDeployment.builder()
+    public final static AutoDeployment AUTO_DEPLOYMENT_ENABLED = AutoDeployment.builder()
             .enabled(true)
             .retainStacksOnAccountRemoval(true)
+            .build();
+
+    public final static AutoDeployment AUTO_DEPLOYMENT_ENABLED_COPY = AutoDeployment.builder()
+            .enabled(true)
+            .retainStacksOnAccountRemoval(true)
+            .build();
+
+    public final static AutoDeployment AUTO_DEPLOYMENT_DISABLED = AutoDeployment.builder()
+            .enabled(false)
+            .retainStacksOnAccountRemoval(false)
             .build();
 
     public final static GetTemplateSummaryResponse VALID_TEMPLATE_SUMMARY_RESPONSE = GetTemplateSummaryResponse.builder()
@@ -402,7 +422,7 @@ public class TestUtils {
             .permissionModel(SERVICE_MANAGED)
             .capabilities(CAPABILITIES)
             .description(DESCRIPTION)
-            .autoDeployment(AUTO_DEPLOYMENT)
+            .autoDeployment(AUTO_DEPLOYMENT_ENABLED)
             .templateBody(TEMPLATE_BODY)
             .stackInstancesGroup(new HashSet<>(Arrays.asList(SERVICE_MANAGED_STACK_INSTANCES_1, SERVICE_MANAGED_STACK_INSTANCES_2)))
             .parameters(new HashSet<>(Arrays.asList(PARAMETER_1, PARAMETER_2)))
@@ -553,7 +573,7 @@ public class TestUtils {
     public final static ResourceModel SERVICE_MANAGED_MODEL_FOR_READ = ResourceModel.builder()
             .stackSetId(STACK_SET_ID)
             .permissionModel(SERVICE_MANAGED)
-            .autoDeployment(AUTO_DEPLOYMENT)
+            .autoDeployment(AUTO_DEPLOYMENT_ENABLED)
             .capabilities(CAPABILITIES)
             .templateBody(TEMPLATE_BODY)
             .description(DESCRIPTION)


### PR DESCRIPTION
*Issue #38*


### *Description of changes:*
* Fix StackSet Update - Update will be not triggered if only update Parameters/AutoDeployment

### Testing
- [X] Manual test passed
    - Only update `AutoDeployment` 
    - Only update `Parameters`
- [X] Integration test passed

### Testing Template
```
Resources:
  TestStackSet:
    Type: AWS::CloudFormation::StackSet
    Properties:
      StackSetName: StackSet-UpdateTest
      Description: Description
      PermissionModel: SERVICE_MANAGED
      AutoDeployment:
        Enabled: true
        RetainStacksOnAccountRemoval: true
      Parameters:
        - ParameterKey: Number
          ParameterValue: 150
      TemplateBody: |
        Parameters:
          Number:
            Type: "String"
        Resources:
          WaitCondition: 
            Type: AWS::CloudFormation::WaitCondition
            Properties: 
              Timeout: !Ref Number
Outputs:
  StackSetId:
    Value: !Ref TestStackSet
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
