### PR TITLE
do not check if module default version exists

### DIFF
--- a/.github/workflows/java-ci-with-maven.yml
+++ b/.github/workflows/java-ci-with-maven.yml
@@ -1,0 +1,44 @@
+
+# This workflow will build a Java project with Maven
+# For more information see: https://help.github.com/actions/language-and-framework-guides/building-and-testing-java-with-maven
+
+name: Java CI with Maven
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+    env:
+      AWS_DEFAULT_REGION: us-east-1
+      AWS_REGION: us-east-1
+
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up JDK 1.8
+      uses: actions/setup-java@v1
+      with:
+        java-version: 1.8
+    - name: Set up Python 3.8
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.8
+    - name: Set up cloudformation-cli-java-plugin
+      run: pip install cloudformation-cli-java-plugin
+    - name: install and run pre-commit
+      uses: pre-commit/action@v2.0.0
+      with:
+        extra_args: --all-files
+    - name: Run maven verify for all resources
+      run: |
+        for directory in $GITHUB_WORKSPACE/aws-*; do
+          cd "$directory"
+          mvn -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn -B clean verify
+        done
+    - name: Failure diff
+      if: ${{ failure() }}
+      run: git diff

--- a/aws-cloudformation-moduledefaultversion/src/main/java/software/amazon/cloudformation/moduledefaultversion/CreateHandler.java
+++ b/aws-cloudformation-moduledefaultversion/src/main/java/software/amazon/cloudformation/moduledefaultversion/CreateHandler.java
@@ -39,40 +39,12 @@ public class CreateHandler extends BaseHandlerStd {
         final ResourceModel model = request.getDesiredResourceState();
         validateModel(model);
 
-        if (defaultVersionExists(proxy, request, callbackContext, proxyClient)) {
-            throw new CfnAlreadyExistsException(ResourceModel.TYPE_NAME, model.getPrimaryIdentifier().toString());
-        }
-
         return proxy.initiate("AWS-CloudFormation-ModuleDefaultVersion::Create", proxyClient, model, callbackContext)
                 .translateToServiceRequest(Translator::translateToCreateRequest)
                 .makeServiceCall((request1, proxyClient1) -> setModuleDefaultVersion(request1, proxyClient, model))
                 .done(progress -> model.getArn() == null // read is only required if Arn is not present
                         ? readHandler.handleRequest(proxy, request, callbackContext, proxyClient, logger)
                         : ProgressEvent.defaultSuccessHandler(model));
-    }
-
-    private boolean defaultVersionExists(
-            final AmazonWebServicesClientProxy proxy,
-            final ResourceHandlerRequest<ResourceModel> request,
-            final CallbackContext callbackContext,
-            final ProxyClient<CloudFormationClient> proxyClient) {
-
-        ProgressEvent<ResourceModel, CallbackContext> response;
-        try {
-            response = readHandler.handleRequest(proxy, request, callbackContext, proxyClient, logger);
-        } catch (final CfnNotFoundException exception) {
-            return false;
-        }
-
-        if (response.isFailed()) {
-            if (response.getErrorCode() != null && response.getErrorCode() != HandlerErrorCode.NotFound) {
-                logger.log(String.format("Unexpected error code while checking if module default version exists: %s", response.getErrorCode()));
-                throw new CfnGeneralServiceException("module default version existence check");
-            }
-            return false; // attempt to set default version on a failed read
-        }
-
-        return true;
     }
 
     private SetTypeDefaultVersionResponse setModuleDefaultVersion(

--- a/aws-cloudformation-moduledefaultversion/src/test/java/software/amazon/cloudformation/moduledefaultversion/CreateHandlerTest.java
+++ b/aws-cloudformation-moduledefaultversion/src/test/java/software/amazon/cloudformation/moduledefaultversion/CreateHandlerTest.java
@@ -169,8 +169,8 @@ public class CreateHandlerTest extends AbstractMockTestBase<CloudFormationClient
     @Test
     public void handleRequest_SetDefaultVersion_NotFound_ModuleNameVersionIdInput() {
         final ResourceModel modelIn = ResourceModel.builder()
-                .moduleName("foo")
-                .versionId("00001")
+                .moduleName(moduleName)
+                .versionId(versionId)
                 .build();
 
         final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()

--- a/aws-cloudformation-moduledefaultversion/src/test/java/software/amazon/cloudformation/moduledefaultversion/CreateHandlerTest.java
+++ b/aws-cloudformation-moduledefaultversion/src/test/java/software/amazon/cloudformation/moduledefaultversion/CreateHandlerTest.java
@@ -23,7 +23,11 @@ import software.amazon.cloudformation.test.AbstractMockTestBase;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.verifyZeroInteractions;
 
 @ExtendWith(MockitoExtension.class)
 public class CreateHandlerTest extends AbstractMockTestBase<CloudFormationClient> {


### PR DESCRIPTION

*Issue #, if available:*
#49 

*Description of changes:*
I had looked at checking if the default version is the _same_ as the one that we're trying to set. But it seems that that the API doesn't throw an error in that case. The only issue I can see is that this could allow a different stack to manage the same default version resource.

[ResourceDefaultVersion ](https://github.com/aws-cloudformation/aws-cloudformation-resource-providers-cloudformation/blob/master/aws-cloudformation-resourcedefaultversion/src/main/java/software/amazon/cloudformation/resourcedefaultversion/CreateHandler.java)does not have this check.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
