### PR TITLE
Add createOnlyProperties to the ResourceVersion resource

### DIFF
--- a/aws-cloudformation-resourceversion/aws-cloudformation-resourceversion.json
+++ b/aws-cloudformation-resourceversion/aws-cloudformation-resourceversion.json
@@ -82,6 +82,9 @@
     "SchemaHandlerPackage",
     "TypeName"
   ],
+  "writeOnlyProperties": [
+    "/properties/SchemaHandlerPackage"
+    ],
   "readOnlyProperties": [
     "/properties/Arn",
     "/properties/IsDefaultVersion",

--- a/aws-cloudformation-resourceversion/aws-cloudformation-resourceversion.json
+++ b/aws-cloudformation-resourceversion/aws-cloudformation-resourceversion.json
@@ -84,7 +84,7 @@
   ],
   "writeOnlyProperties": [
     "/properties/SchemaHandlerPackage"
-    ],
+  ],
   "readOnlyProperties": [
     "/properties/Arn",
     "/properties/IsDefaultVersion",

--- a/aws-cloudformation-resourceversion/aws-cloudformation-resourceversion.json
+++ b/aws-cloudformation-resourceversion/aws-cloudformation-resourceversion.json
@@ -90,8 +90,11 @@
     "/properties/VersionId",
     "/properties/TypeArn"
   ],
-  "writeOnlyProperties": [
-    "/properties/SchemaHandlerPackage"
+  "createOnlyProperties": [
+    "/properties/ExecutionRoleArn",
+    "/properties/LoggingConfig",
+    "/properties/SchemaHandlerPackage",
+    "/properties/TypeName"
   ],
   "primaryIdentifier": [
     "/properties/Arn"


### PR DESCRIPTION
*Description of changes:*

Having the properties -ExecutionRoleArn, LoggingConfig, SchemaHandlerPackage and TypeName as createOnly would make it clear that no properties are updatable for this resource. Also makes it clear that they cause a replacement.

Reference customer PR: https://github.com/aws-cloudformation/aws-cloudformation-resource-providers-cloudformation/pull/24

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
