### PR TITLE
StackSets - Tag Key allows colon

### DIFF
--- a/aws-cloudformation-stackset/aws-cloudformation-stackset.json
+++ b/aws-cloudformation-stackset/aws-cloudformation-stackset.json
@@ -18,7 +18,7 @@
           "type": "string",
           "minLength": 1,
           "maxLength": 128,
-          "pattern": "^(?!aws:.*)[a-zA-Z0-9\\s\\_\\.\\/\\=\\+\\-]+$"
+          "pattern": "^(?!aws:.*)[a-zA-Z0-9\\s\\:\\_\\.\\/\\=\\+\\-]+$"
         },
         "Value": {
           "description": "A string containing the value for this tag. You can specify a maximum of 256 characters for a tag value.",


### PR DESCRIPTION
*Issue #, if available:*

Customers report that `:` is disallowed in StackSet resource while is allowed in Stack resource and StackSets service.

*Description of changes:*

Update TagKey pattern to allow `:`

*Testing*:

* RegEx testing
* Manual build


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
