### PR TITLE
Include ClientRequestToken in call to RegisterType

### DIFF
--- a/aws-cloudformation-moduleversion/src/main/java/software/amazon/cloudformation/moduleversion/Translator.java
+++ b/aws-cloudformation-moduleversion/src/main/java/software/amazon/cloudformation/moduleversion/Translator.java
@@ -15,6 +15,7 @@ import software.amazon.awssdk.services.cloudformation.model.RegisterTypeRequest;
 import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
+import java.util.UUID;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -39,6 +40,7 @@ public class Translator {
                 .schemaHandlerPackage(model.getModulePackage())
                 .type("MODULE")
                 .typeName(model.getModuleName())
+                .clientRequestToken(UUID.randomUUID().toString())
                 .build();
     }
 

--- a/aws-cloudformation-moduleversion/src/test/java/software/amazon/cloudformation/moduleversion/TranslatorTest.java
+++ b/aws-cloudformation-moduleversion/src/test/java/software/amazon/cloudformation/moduleversion/TranslatorTest.java
@@ -50,6 +50,7 @@ public class TranslatorTest {
         assertThat(registerTypeRequest.schemaHandlerPackage()).isEqualTo(model.getModulePackage());
         assertThat(registerTypeRequest.typeAsString()).isEqualTo("MODULE");
         assertThat(registerTypeRequest.typeName()).isEqualTo(model.getModuleName());
+        assertThat(registerTypeRequest.clientRequestToken()).isNotEmpty();
     }
 
     @Test


### PR DESCRIPTION
Including a clientRequestToken when calling register-type. This can help when investigating issues on the registry side

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
