### PR TITLE
SkyTrain-NS-259 Bugfix: Ensure same client request token is used when register-type is resent

### DIFF
--- a/aws-cloudformation-moduledefaultversion/.rpdk-config
+++ b/aws-cloudformation-moduledefaultversion/.rpdk-config
@@ -1,4 +1,5 @@
 {
+    "artifact_type": "RESOURCE",
     "typeName": "AWS::CloudFormation::ModuleDefaultVersion",
     "language": "java",
     "runtime": "java8",
@@ -13,5 +14,6 @@
         ],
         "codegen_template_path": "guided_aws",
         "protocolVersion": "2.0.0"
-    }
+    },
+    "executableEntrypoint": "software.amazon.cloudformation.moduledefaultversion.HandlerWrapperExecutable"
 }

--- a/aws-cloudformation-moduleversion/src/main/java/software/amazon/cloudformation/moduleversion/CallbackContext.java
+++ b/aws-cloudformation-moduleversion/src/main/java/software/amazon/cloudformation/moduleversion/CallbackContext.java
@@ -23,6 +23,10 @@ public class CallbackContext extends StdCallbackContext {
     private String registrationToken;
 
     @Getter
+    @Setter
+    private String clientRequestToken;
+
+    @Getter
     private List<ResourceModel> modulesToList;
 
     @Getter

--- a/aws-cloudformation-moduleversion/src/main/java/software/amazon/cloudformation/moduleversion/Translator.java
+++ b/aws-cloudformation-moduleversion/src/main/java/software/amazon/cloudformation/moduleversion/Translator.java
@@ -15,7 +15,6 @@ import software.amazon.awssdk.services.cloudformation.model.RegisterTypeRequest;
 import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
-import java.util.UUID;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -35,12 +34,12 @@ public class Translator {
     * @param model resource model
     * @return the aws service request to create a resource
     */
-    static RegisterTypeRequest translateToCreateRequest(@NonNull final ResourceModel model) {
+    static RegisterTypeRequest translateToCreateRequest(@NonNull final ResourceModel model, @NonNull final String clientRequestToken) {
         return RegisterTypeRequest.builder()
                 .schemaHandlerPackage(model.getModulePackage())
                 .type("MODULE")
                 .typeName(model.getModuleName())
-                .clientRequestToken(UUID.randomUUID().toString())
+                .clientRequestToken(clientRequestToken)
                 .build();
     }
 

--- a/aws-cloudformation-moduleversion/src/test/java/software/amazon/cloudformation/moduleversion/TranslatorTest.java
+++ b/aws-cloudformation-moduleversion/src/test/java/software/amazon/cloudformation/moduleversion/TranslatorTest.java
@@ -32,7 +32,7 @@ public class TranslatorTest {
 
     @Test
     public void translateToCreateRequest_NullResourceModel() {
-        assertThatThrownBy(() -> Translator.translateToCreateRequest(null))
+        assertThatThrownBy(() -> Translator.translateToCreateRequest(null, "clientRequestToken"))
                 .hasNoCause()
                 .hasMessageStartingWith("model is marked")
                 .isExactlyInstanceOf(NullPointerException.class);
@@ -40,17 +40,18 @@ public class TranslatorTest {
 
     @Test
     public void translateToCreateRequest_Success() {
+        final String clientRequestToken = "fuwtvh8";
         final ResourceModel model = ResourceModel.builder()
                 .modulePackage(modulePackage)
                 .moduleName(moduleName)
                 .build();
 
-        final RegisterTypeRequest registerTypeRequest = Translator.translateToCreateRequest(model);
+        final RegisterTypeRequest registerTypeRequest = Translator.translateToCreateRequest(model, clientRequestToken);
 
         assertThat(registerTypeRequest.schemaHandlerPackage()).isEqualTo(model.getModulePackage());
         assertThat(registerTypeRequest.typeAsString()).isEqualTo("MODULE");
         assertThat(registerTypeRequest.typeName()).isEqualTo(model.getModuleName());
-        assertThat(registerTypeRequest.clientRequestToken()).isNotEmpty();
+        assertThat(registerTypeRequest.clientRequestToken()).isEqualTo(clientRequestToken);
     }
 
     @Test


### PR DESCRIPTION
The CreateHandler is being called multiple times by the CloudFormation framework (documented for example [here](https://docs.aws.amazon.com/cloudformation-cli/latest/userguide/resource-type-walkthrough.html)), so we have to make sure it's idempotent. To do that we ensure the same clientRequestToken is sent along with the register type call. The current bug is triggered because the random clientRequestTokens cause the hash of the RegisterTypeRequest to be different between CreateHandler invokation which causes CFN to resend the request (see [hashing of the request here](https://github.com/aws-cloudformation/cloudformation-cli-java-plugin/blob/master/src/main/java/software/amazon/cloudformation/proxy/AmazonWebServicesClientProxy.java#L265))

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
