### PR TITLE
Adopting the AWS Java SDK's Standard Retry Mode

### DIFF
--- a/aws-cloudformation-moduledefaultversion/src/main/java/software/amazon/cloudformation/moduledefaultversion/ClientBuilder.java
+++ b/aws-cloudformation-moduledefaultversion/src/main/java/software/amazon/cloudformation/moduledefaultversion/ClientBuilder.java
@@ -1,5 +1,6 @@
 package software.amazon.cloudformation.moduledefaultversion;
 
+import software.amazon.awssdk.core.retry.RetryMode;
 import software.amazon.awssdk.services.cloudformation.CloudFormationClient;
 import software.amazon.cloudformation.LambdaWrapper;
 
@@ -7,6 +8,7 @@ public class ClientBuilder {
     public static CloudFormationClient getClient() {
         return CloudFormationClient.builder()
                 .httpClient(LambdaWrapper.HTTP_CLIENT)
+                .overrideConfiguration(c -> c.retryPolicy(RetryMode.STANDARD))
                 .build();
     }
 }

--- a/aws-cloudformation-moduleversion/src/main/java/software/amazon/cloudformation/moduleversion/ClientBuilder.java
+++ b/aws-cloudformation-moduleversion/src/main/java/software/amazon/cloudformation/moduleversion/ClientBuilder.java
@@ -1,5 +1,6 @@
 package software.amazon.cloudformation.moduleversion;
 
+import software.amazon.awssdk.core.retry.RetryMode;
 import software.amazon.awssdk.services.cloudformation.CloudFormationClient;
 import software.amazon.cloudformation.LambdaWrapper;
 
@@ -7,6 +8,7 @@ public class ClientBuilder {
     public static CloudFormationClient getClient() {
         return CloudFormationClient.builder()
                 .httpClient(LambdaWrapper.HTTP_CLIENT)
+                .overrideConfiguration(c -> c.retryPolicy(RetryMode.STANDARD))
                 .build();
     }
 }

--- a/aws-cloudformation-resourcedefaultversion/src/main/java/software/amazon/cloudformation/resourcedefaultversion/ClientBuilder.java
+++ b/aws-cloudformation-resourcedefaultversion/src/main/java/software/amazon/cloudformation/resourcedefaultversion/ClientBuilder.java
@@ -1,5 +1,6 @@
 package software.amazon.cloudformation.resourcedefaultversion;
 
+import software.amazon.awssdk.core.retry.RetryMode;
 import software.amazon.awssdk.services.cloudformation.CloudFormationClient;
 import software.amazon.cloudformation.LambdaWrapper;
 
@@ -8,6 +9,7 @@ public class ClientBuilder {
     public static CloudFormationClient getClient() {
         return CloudFormationClient.builder()
             .httpClient(LambdaWrapper.HTTP_CLIENT)
+            .overrideConfiguration(c -> c.retryPolicy(RetryMode.STANDARD))
             .build();
     }
 }

--- a/aws-cloudformation-resourceversion/src/main/java/software/amazon/cloudformation/resourceversion/ClientBuilder.java
+++ b/aws-cloudformation-resourceversion/src/main/java/software/amazon/cloudformation/resourceversion/ClientBuilder.java
@@ -1,5 +1,6 @@
 package software.amazon.cloudformation.resourceversion;
 
+import software.amazon.awssdk.core.retry.RetryMode;
 import software.amazon.awssdk.services.cloudformation.CloudFormationClient;
 import software.amazon.cloudformation.LambdaWrapper;
 
@@ -8,6 +9,7 @@ public class ClientBuilder {
     public static CloudFormationClient getClient() {
         return CloudFormationClient.builder()
             .httpClient(LambdaWrapper.HTTP_CLIENT)
+            .overrideConfiguration(c -> c.retryPolicy(RetryMode.STANDARD))
             .build();
     }
 }

--- a/aws-cloudformation-typedefaultversion/src/main/java/software/amazon/cloudformation/typedefaultversion/ClientBuilder.java
+++ b/aws-cloudformation-typedefaultversion/src/main/java/software/amazon/cloudformation/typedefaultversion/ClientBuilder.java
@@ -1,5 +1,6 @@
 package software.amazon.cloudformation.typedefaultversion;
 
+import software.amazon.awssdk.core.retry.RetryMode;
 import software.amazon.awssdk.services.cloudformation.CloudFormationClient;
 import software.amazon.cloudformation.LambdaWrapper;
 
@@ -7,6 +8,7 @@ public class ClientBuilder {
   public static CloudFormationClient getClient() {
     return CloudFormationClient.builder()
               .httpClient(LambdaWrapper.HTTP_CLIENT)
+              .overrideConfiguration(c -> c.retryPolicy(RetryMode.STANDARD))
               .build();
   }
 

--- a/aws-cloudformation-typeversion/src/main/java/software/amazon/cloudformation/typeversion/ClientBuilder.java
+++ b/aws-cloudformation-typeversion/src/main/java/software/amazon/cloudformation/typeversion/ClientBuilder.java
@@ -1,5 +1,6 @@
 package software.amazon.cloudformation.typeversion;
 
+import software.amazon.awssdk.core.retry.RetryMode;
 import software.amazon.awssdk.services.cloudformation.CloudFormationClient;
 import software.amazon.cloudformation.LambdaWrapper;
 
@@ -8,6 +9,7 @@ public class ClientBuilder {
    public static CloudFormationClient getClient() {
     return CloudFormationClient.builder()
               .httpClient(LambdaWrapper.HTTP_CLIENT)
+              .overrideConfiguration(c -> c.retryPolicy(RetryMode.STANDARD))
               .build();
   }
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Update AWS cloudformation client configurations to use new STANDARD mode.
Note:  I did not make changes to stackset retry mode as current retry mode already overridden so not changing it.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
