### PR TITLE
StackSets - Fix UpdateStackInstances only running once when called wi…

### DIFF
--- a/aws-cloudformation-stackset/src/main/java/software/amazon/cloudformation/stackset/BaseHandlerStd.java
+++ b/aws-cloudformation-stackset/src/main/java/software/amazon/cloudformation/stackset/BaseHandlerStd.java
@@ -249,7 +249,7 @@ public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
                     })
                     .stabilize((request, response, proxyInvocation, resourceModel, context) -> isOperationStabilized(proxyInvocation, resourceModel, response.operationId(), logger))
                     .retryErrorFilter(this::filterException)
-                    .progress();
+                    .success();
 
             if (!progressEvent.isSuccess()) {
                 return progressEvent;


### PR DESCRIPTION
UpdateStackInstances was only being called once, regardless of the number of stack instance groups that needed to be updated.

- Replaced progress() with success() in progress event chain

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
