### PR TITLE
StackSets - Allow template URL to be up to 5120 bytes long

### DIFF
--- a/aws-cloudformation-stackset/aws-cloudformation-stackset.json
+++ b/aws-cloudformation-stackset/aws-cloudformation-stackset.json
@@ -284,7 +284,7 @@
       "description": "Location of file containing the template body. The URL must point to a template (max size: 460,800 bytes) that is located in an Amazon S3 bucket.",
       "type": "string",
       "minLength": 1,
-      "maxLength": 1024
+      "maxLength": 5120
     },
     "CallAs": {
       "description": "Specifies the AWS account that you are acting from. By default, SELF is specified. For self-managed permissions, specify SELF; for service-managed permissions, if you are signed in to the organization's management account, specify SELF. If you are signed in to a delegated administrator account, specify DELEGATED_ADMIN.",


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:Allow StackSets to use template URL up to 5120 bytes long, consistent with API.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
