### PR TITLE
[ModuleVersion] Remove DocumentationUrl from readOnlyProperties

### DIFF
--- a/aws-cloudformation-moduleversion/aws-cloudformation-moduleversion.json
+++ b/aws-cloudformation-moduleversion/aws-cloudformation-moduleversion.json
@@ -66,7 +66,6 @@
   "readOnlyProperties": [
     "/properties/Arn",
     "/properties/Description",
-    "/properties/DocumentationUrl",
     "/properties/IsDefaultVersion",
     "/properties/Schema",
     "/properties/TimeCreated",


### PR DESCRIPTION
The ModuleVersion resource is currently not adhering to the [Resource type handler contract](https://docs.aws.amazon.com/cloudformation-cli/latest/userguide/resource-type-test-contract.html) specifically the rule that says that all readOnlyProperties must be returned in a read request. Theoretically, it would be a backwards-incompatible change to remove a property from readOnlyProperties, but since we have never returned this value in read requests in practice, this change won't break any existing customers.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
