### PR TITLE
[ModuleVersion] Return empty string instead of null for DocumentationUrl

### DIFF
--- a/aws-cloudformation-moduleversion/aws-cloudformation-moduleversion.json
+++ b/aws-cloudformation-moduleversion/aws-cloudformation-moduleversion.json
@@ -66,6 +66,7 @@
   "readOnlyProperties": [
     "/properties/Arn",
     "/properties/Description",
+    "/properties/DocumentationUrl",
     "/properties/IsDefaultVersion",
     "/properties/Schema",
     "/properties/TimeCreated",

--- a/aws-cloudformation-moduleversion/src/main/java/software/amazon/cloudformation/moduleversion/Translator.java
+++ b/aws-cloudformation-moduleversion/src/main/java/software/amazon/cloudformation/moduleversion/Translator.java
@@ -71,10 +71,11 @@ public class Translator {
      * @return resource model
      */
     static ResourceModel translateFromReadResponse(@NonNull final DescribeTypeResponse response) {
+        String documentationUrl = response.documentationUrl() != null ? response.documentationUrl() : "";
         return ResourceModel.builder()
                 .arn(response.arn())
                 .description(response.description())
-                .documentationUrl(response.documentationUrl())
+                .documentationUrl(documentationUrl)
                 .isDefaultVersion(response.isDefaultVersion())
                 .moduleName(response.typeName())
                 .schema(response.schema())


### PR DESCRIPTION
*Description of changes:*
I made a mistake in my last PR. I can't remove DocumentationUrl from the readOnlyProperties, because that would enable users to specify it in the template which is not how the attribute is intended to be used. The contract tests are complaining that we're not always returning the documentationUrl. Removing it would be backwards-incompatible, so to adhere to the resource type contract we'll return an empty string when the module doesn't have a documentationUrl.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
