### PR TITLE
Disable ModuleVersion ListHandler

### DIFF
--- a/aws-cloudformation-moduleversion/aws-cloudformation-moduleversion.json
+++ b/aws-cloudformation-moduleversion/aws-cloudformation-moduleversion.json
@@ -100,12 +100,6 @@
         "cloudformation:DeregisterType",
         "cloudformation:DescribeType"
       ]
-    },
-    "list": {
-      "permissions": [
-        "cloudformation:ListTypes",
-        "cloudformation:ListTypeVersions"
-      ]
     }
   },
   "additionalProperties": false


### PR DESCRIPTION
The ListHandler of the ModuleVersion resource does not behave as expected. It always returns an empty response because the paging logic is not implemented properly. Fixing it is no trivial, because we need to iterate over an unknown number of lists (the list of modules and for each module the list of versions), each of which has an iteration token. So, we should disable it to reduce confusion for customers. It's better to return a clear message saying the list handler is not supported than returning an incorrect response. We'll work on fixing the handler in the meantime.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
