### PR TITLE
Make ModuleDefaultVersion ListHandler conform to contract tests

### DIFF
--- a/aws-cloudformation-moduledefaultversion/pom.xml
+++ b/aws-cloudformation-moduledefaultversion/pom.xml
@@ -16,14 +16,14 @@
         <maven.compiler.target>1.8</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+        <mockito.version>2.28.2</mockito.version>
     </properties>
 
     <dependencies>
-        <!-- Can be removed when https://github.com/aws-cloudformation/cloudformation-cli-java-plugin/pull/267 is merged -->
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>cloudformation</artifactId>
-            <version>2.13.18</version>
+            <version>2.19.0</version>
         </dependency>
         <!-- Test dependency for Java Providers -->
         <dependency>
@@ -35,13 +35,13 @@
         <dependency>
             <groupId>software.amazon.cloudformation</groupId>
             <artifactId>aws-cloudformation-rpdk-java-plugin</artifactId>
-            <version>2.0.12</version>
+            <version>2.0.14</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/org.projectlombok/lombok -->
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
-            <version>1.18.22</version>
+            <version>1.18.26</version>
             <scope>provided</scope>
         </dependency>
 
@@ -56,21 +56,21 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
-            <version>5.5.0-M1</version>
+            <version>5.9.2</version>
             <scope>test</scope>
         </dependency>
         <!-- https://mvnrepository.com/artifact/org.mockito/mockito-core -->
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <version>2.28.2</version>
+            <version>${mockito.version}</version>
             <scope>test</scope>
         </dependency>
         <!-- https://mvnrepository.com/artifact/org.mockito/mockito-junit-jupiter -->
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-junit-jupiter</artifactId>
-            <version>2.28.2</version>
+            <version>${mockito.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>
@@ -80,7 +80,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.10.1</version>
+                <version>3.11.0</version>
                 <configuration>
                     <compilerArgs>
                         <arg>-Xlint:all,-options,-processing</arg>
@@ -91,7 +91,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
-                <version>3.2.0</version>
+                <version>3.4.1</version>
                 <configuration>
                     <createDependencyReducedPom>false</createDependencyReducedPom>
                 </configuration>
@@ -207,6 +207,13 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-checkstyle-plugin</artifactId>
                 <version>3.1.2</version>
+                <dependencies>
+                    <dependency>
+                        <groupId>com.puppycrawl.tools</groupId>
+                        <artifactId>checkstyle</artifactId>
+                        <version>8.45.1</version>
+                    </dependency>
+                </dependencies>
                 <configuration>
                     <configLocation>../checkstyle.xml</configLocation>
                     <encoding>UTF-8</encoding>

--- a/aws-cloudformation-moduledefaultversion/src/main/java/software/amazon/cloudformation/moduledefaultversion/Translator.java
+++ b/aws-cloudformation-moduledefaultversion/src/main/java/software/amazon/cloudformation/moduledefaultversion/Translator.java
@@ -85,7 +85,7 @@ public class Translator {
                 .map(summary -> ResourceModel.builder()
                         .moduleName(summary.typeName())
                         .versionId(summary.defaultVersionId())
-                        .arn(summary.typeArn())
+                        .arn(summary.typeArn() + "/" + summary.defaultVersionId())
                         .build())
                 .collect(Collectors.toList());
     }

--- a/aws-cloudformation-moduledefaultversion/src/test/java/software/amazon/cloudformation/moduledefaultversion/ListHandlerTest.java
+++ b/aws-cloudformation-moduledefaultversion/src/test/java/software/amazon/cloudformation/moduledefaultversion/ListHandlerTest.java
@@ -60,7 +60,7 @@ public class ListHandlerTest extends AbstractMockTestBase<CloudFormationClient> 
                 .nextToken(NEXT_TOKEN)
                 .build();
         final ResourceModel expectedResourceModel = ResourceModel.builder()
-                .arn(MODULE_ARN)
+                .arn(MODULE_ARN + "/" + DEFAULT_VERSION_ID)
                 .moduleName(MODULE_NAME)
                 .versionId(DEFAULT_VERSION_ID)
                 .build();


### PR DESCRIPTION
The contract tests expect that the ListHandler returns the default module versions, not the module itself.

Currently, when we invoke the ListHandler we get the Module arns like this:
```bash
aws cloudcontrol list-resources --type-name AWS::CloudFormation::ModuleDefaultVersion --region us-west-2
```

```json
{
    "ResourceDescriptions": [
        {
            "Identifier": "arn:aws:cloudformation:us-west-2:123:type/module/Malik-mm-mm-MODULE",
            "Properties": "{\"ModuleName\":\"Malik::mm::mm::MODULE\",\"Arn\":\"arn:aws:cloudformation:us-west-2:123:type/module/Malik-mm-mm-MODULE\"}"
        }
    ],
    "TypeName": "AWS::CloudFormation::ModuleDefaultVersion"
}
```

But, the expected output according to the resource contract is like this:

```json
{
    "ResourceDescriptions": [
        {
            "Identifier": "arn:aws:cloudformation:us-west-2:123:type/module/Malik-mm-mm-MODULE/00000001",
            "Properties": "{\"ModuleName\":\"Malik::mm::mm::MODULE\",\"Arn\":\"arn:aws:cloudformation:us-west-2:123:type/module/Malik-mm-mm-MODULE\"}"
        }
    ],
    "TypeName": "AWS::CloudFormation::ModuleDefaultVersion"
}
```



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
