### PR TITLE
[Maestro-14785] Fix DeploymentTarget - AccountURL in resource handler and documentation

### DIFF
--- a/aws-cloudformation-stackset/aws-cloudformation-stackset.json
+++ b/aws-cloudformation-stackset/aws-cloudformation-stackset.json
@@ -146,6 +146,13 @@
             "$ref": "#/definitions/Account"
           }
         },
+        "AccountsUrl": {
+          "description": "Returns the value of the AccountsUrl property.",
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 5120,
+          "pattern": "(s3://|http(s?)://).+"
+        },
         "OrganizationalUnitIds": {
           "description": "The organization root ID or organizational unit (OU) IDs to which StackSets deploys.",
           "type": "array",

--- a/aws-cloudformation-stackset/docs/deploymenttargets.md
+++ b/aws-cloudformation-stackset/docs/deploymenttargets.md
@@ -11,6 +11,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 <pre>
 {
     "<a href="#accounts" title="Accounts">Accounts</a>" : <i>[ String, ... ]</i>,
+    "<a href="#accountsUrl" title="AccountsUrl">AccountsUrl</a>" : <i>String</i>,
     "<a href="#organizationalunitids" title="OrganizationalUnitIds">OrganizationalUnitIds</a>" : <i>[ String, ... ]</i>,
     "<a href="#accountfiltertype" title="AccountFilterType">AccountFilterType</a>" : <i>String</i>
 }
@@ -21,6 +22,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 <pre>
 <a href="#accounts" title="Accounts">Accounts</a>: <i>
       - String</i>
+<a href="#accountsurl" title="AccountsUrl">AccountsUrl</a>: <i>String</i>
 <a href="#organizationalunitids" title="OrganizationalUnitIds">OrganizationalUnitIds</a>: <i>
       - String</i>
 <a href="#accountfiltertype" title="AccountFilterType">AccountFilterType</a>: <i>String</i>
@@ -35,6 +37,20 @@ AWS accounts that you want to create stack instances in the specified Region(s) 
 _Required_: No
 
 _Type_: List of String
+
+_Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
+
+#### AccountsUrl
+
+Returns the value of the AccountsUrl property.
+
+_Required_: No
+
+_Type_: String
+
+_Length Constraints_: Minimum length of 1. Maximum length of 5120.
+
+_Pattern_: `(s3://|http(s?)://).+`
 
 _Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
 

--- a/aws-cloudformation-stackset/src/main/java/software/amazon/cloudformation/stackset/translator/PropertyTranslator.java
+++ b/aws-cloudformation-stackset/src/main/java/software/amazon/cloudformation/stackset/translator/PropertyTranslator.java
@@ -61,6 +61,7 @@ public class PropertyTranslator {
             final software.amazon.cloudformation.stackset.DeploymentTargets deploymentTargets) {
         return DeploymentTargets.builder()
                 .accounts(deploymentTargets.getAccounts())
+                .accountsUrl(deploymentTargets.getAccountsUrl())
                 .organizationalUnitIds(deploymentTargets.getOrganizationalUnitIds())
                 .accountFilterType(deploymentTargets.getAccountFilterType())
                 .build();

--- a/aws-cloudformation-stackset/src/test/java/software/amazon/cloudformation/stackset/translator/PropertyTranslatorTest.java
+++ b/aws-cloudformation-stackset/src/test/java/software/amazon/cloudformation/stackset/translator/PropertyTranslatorTest.java
@@ -21,6 +21,7 @@ import static software.amazon.cloudformation.stackset.translator.PropertyTransla
 import static software.amazon.cloudformation.stackset.translator.PropertyTranslator.translateToSdkOperationPreferences;
 import static software.amazon.cloudformation.stackset.translator.PropertyTranslator.translateToSdkTags;
 import static software.amazon.cloudformation.stackset.translator.PropertyTranslator.translateToStackInstance;
+import static software.amazon.cloudformation.stackset.util.AltTestUtils.ACCOUNTS_URL;
 import static software.amazon.cloudformation.stackset.util.AltTestUtils.INTER;
 import static software.amazon.cloudformation.stackset.util.AltTestUtils.OU_1;
 import static software.amazon.cloudformation.stackset.util.AltTestUtils.account_1;
@@ -86,10 +87,12 @@ public class PropertyTranslatorTest {
 
     @Test
     public void test_translateToSdkDeploymentTargets() {
+        String testaccountsUrl
         software.amazon.cloudformation.stackset.DeploymentTargets deploymentTargets =
                 software.amazon.cloudformation.stackset.DeploymentTargets.builder()
                         .organizationalUnitIds(new HashSet<>(Arrays.asList(OU_1)))
                         .accounts(new HashSet<>(Arrays.asList(account_1)))
+                        .accountsUrl(ACCOUNTS_URL)
                         .accountFilterType(INTER)
                         .build();
 
@@ -99,6 +102,7 @@ public class PropertyTranslatorTest {
                 .isEqualTo(new HashSet<>(Arrays.asList(OU_1)));
         assertThat(new HashSet<>(sdkDeploymentTargets.accounts()))
                 .isEqualTo(new HashSet<>(Arrays.asList(account_1)));
+        assertThat(sdkDeploymentTargets.accountsUrl()).isEqualTo(ACCOUNTS_URL);
         assertThat(sdkDeploymentTargets.accountFilterTypeAsString()).isEqualTo(INTER);
 
     }

--- a/aws-cloudformation-stackset/src/test/java/software/amazon/cloudformation/stackset/util/AltTestUtils.java
+++ b/aws-cloudformation-stackset/src/test/java/software/amazon/cloudformation/stackset/util/AltTestUtils.java
@@ -31,6 +31,7 @@ public class AltTestUtils {
     public final static String region_2 = "us-west-1";
     public final static String region_3 = "us-east-2";
     public final static String region_4 = "us-east-1";
+    public final static String ACCOUNTS_URL = "http://test";
 
     public final static Set<String> singleton_region_set = new HashSet<>(Collections.singletonList(region_1));
 


### PR DESCRIPTION
*Issue #, if available:*
Fix DeploymentTarget - AccountURL in resource handler and documentation
https://issues.amazon.com/issues/Maestro-14785 
*Description of changes:*

StackSet as a resource should have feature parity with our APIs, but it does not support **AccountsURL**.

Additionally, the documentation for AccountURL states that DeploymentTargets (and by extension AccountURL) is only for service managed stack sets, but it is actually applicable to both. See https://docs.aws.amazon.com/cli/latest/reference/cloudformation/create-stack-instances.html

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
