### PR TITLE
Handle RegionOrder Preference for ALT

### DIFF
--- a/aws-cloudformation-stackset/src/test/java/software/amazon/cloudformation/stackset/util/AltResourceModelAnalyzerTest.java
+++ b/aws-cloudformation-stackset/src/test/java/software/amazon/cloudformation/stackset/util/AltResourceModelAnalyzerTest.java
@@ -4,12 +4,18 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.Iterator;
+import java.util.LinkedHashSet;
+import java.util.List;
 import java.util.Set;
 import org.junit.jupiter.api.Test;
 import software.amazon.cloudformation.exceptions.CfnInvalidRequestException;
 import software.amazon.cloudformation.stackset.DeploymentTargets;
+import software.amazon.cloudformation.stackset.ManagedExecution;
+import software.amazon.cloudformation.stackset.OperationPreferences;
 import software.amazon.cloudformation.stackset.ResourceModel;
 import software.amazon.cloudformation.stackset.StackInstances;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static software.amazon.cloudformation.stackset.util.AltTestUtils.DIFF;
@@ -55,10 +61,10 @@ public class AltResourceModelAnalyzerTest {
 
         ResourceModel modelNullFilter = generateModel(new HashSet<>(Arrays.asList(
                 StackInstances.builder().deploymentTargets(
-                        DeploymentTargets.builder()
-                                .organizationalUnitIds(new HashSet<>(Arrays.asList(OU_1)))
-                                .accounts(new HashSet<>(Arrays.asList(account_1)))
-                                .build())
+                                DeploymentTargets.builder()
+                                        .organizationalUnitIds(new HashSet<>(Arrays.asList(OU_1)))
+                                        .accounts(new HashSet<>(Arrays.asList(account_1)))
+                                        .build())
                         .build()
         )));
 
@@ -112,21 +118,21 @@ public class AltResourceModelAnalyzerTest {
                         new HashSet<>(Arrays.asList(region_1, region_3)))
         )));
 
-        Set<StackInstances> desiredDeleteInstances = new HashSet<>();
-        Set<StackInstances> desiredCreateInstances = new HashSet<>(Arrays.asList(
+        Set<StackInstances> desiredDeleteInstances = new LinkedHashSet<>();
+        Set<StackInstances> desiredCreateInstances = new LinkedHashSet<>(Arrays.asList(
                 generateInstancesWithRegions(Arrays.asList(OU_1, OU_2), region_1),
                 generateInstancesWithRegions(Arrays.asList(OU_1, OU_2), region_2),
                 generateInstancesWithRegions(Arrays.asList(OU_2, OU_3), Arrays.asList(account_1, account_2), INTER, region_1),
                 generateInstancesWithRegions(Arrays.asList(OU_2, OU_3), Arrays.asList(account_1, account_2), INTER, region_3)
         ));
-        Set<StackInstances> desiredUpdateInstances = new HashSet<>();
+        Set<StackInstances> desiredUpdateInstances = new LinkedHashSet<>();
 
         StackInstancesPlaceHolder placeHolder = new StackInstancesPlaceHolder();
         AltResourceModelAnalyzer.builder().currentModel(currentModel).build().analyze(placeHolder);
 
-        assertThat(Comparator.equals(new HashSet<>(placeHolder.getDeleteStackInstances()), desiredDeleteInstances)).isTrue();
-        assertThat(Comparator.equals(new HashSet<>(placeHolder.getCreateStackInstances()), desiredCreateInstances)).isTrue();
-        assertThat(Comparator.equals(new HashSet<>(placeHolder.getUpdateStackInstances()), desiredUpdateInstances)).isTrue();
+        assertThat(Comparator.equals(new LinkedHashSet<>(placeHolder.getDeleteStackInstances()), desiredDeleteInstances)).isTrue();
+        assertThat(Comparator.equals(new LinkedHashSet<>(placeHolder.getCreateStackInstances()), desiredCreateInstances)).isTrue();
+        assertThat(Comparator.equals(new LinkedHashSet<>(placeHolder.getUpdateStackInstances()), desiredUpdateInstances)).isTrue();
     }
 
     @Test
@@ -138,20 +144,397 @@ public class AltResourceModelAnalyzerTest {
                         new HashSet<>(Arrays.asList(region_1, region_3)))
         )));
 
-        Set<StackInstances> desiredDeleteInstances = new HashSet<>(Arrays.asList(
+        Set<StackInstances> desiredDeleteInstances = new LinkedHashSet<>(Arrays.asList(
                 generateInstancesWithRegions(Arrays.asList(OU_1, OU_2), region_1),
                 generateInstancesWithRegions(Arrays.asList(OU_1, OU_2), region_2),
                 generateInstancesWithRegions(Arrays.asList(OU_2, OU_3), Arrays.asList(account_1, account_2), INTER, region_1),
                 generateInstancesWithRegions(Arrays.asList(OU_2, OU_3), Arrays.asList(account_1, account_2), INTER, region_3)));
-        Set<StackInstances> desiredCreateInstances = new HashSet<>();
-        Set<StackInstances> desiredUpdateInstances = new HashSet<>();
+        Set<StackInstances> desiredCreateInstances = new LinkedHashSet<>();
+        Set<StackInstances> desiredUpdateInstances = new LinkedHashSet<>();
 
         StackInstancesPlaceHolder placeHolder = new StackInstancesPlaceHolder();
         AltResourceModelAnalyzer.builder().previousModel(previousModel).build().analyze(placeHolder);
 
-        assertThat(Comparator.equals(new HashSet<>(placeHolder.getDeleteStackInstances()), desiredDeleteInstances)).isTrue();
-        assertThat(Comparator.equals(new HashSet<>(placeHolder.getCreateStackInstances()), desiredCreateInstances)).isTrue();
-        assertThat(Comparator.equals(new HashSet<>(placeHolder.getUpdateStackInstances()), desiredUpdateInstances)).isTrue();
+        assertThat(Comparator.equals(new LinkedHashSet<>(placeHolder.getDeleteStackInstances()), desiredDeleteInstances)).isTrue();
+        assertThat(Comparator.equals(new LinkedHashSet<>(placeHolder.getCreateStackInstances()), desiredCreateInstances)).isTrue();
+        assertThat(Comparator.equals(new LinkedHashSet<>(placeHolder.getUpdateStackInstances()), desiredUpdateInstances)).isTrue();
+    }
+
+    @Test
+    public void test_ALT_Create_With_OperationPreferences_And_Region_Order() {
+        ResourceModel currentModel = generateModel(new HashSet<>(Collections.singletonList(
+                generateInstancesWithRegions(
+                        Arrays.asList(OU_2, OU_3), Arrays.asList(account_1, account_2), INTER,
+                        new HashSet<>(Arrays.asList(region_1, region_2, region_3)))
+        )));
+        List<String> regionOrder = Arrays.asList(region_3, region_2, region_1);
+        currentModel.setOperationPreferences(new OperationPreferences(null, null, null, null, regionOrder, null));
+
+        Set<StackInstances> desiredDeleteInstances = new LinkedHashSet<>();
+        Set<StackInstances> desiredCreateInstances = new LinkedHashSet<>(Arrays.asList(
+                generateInstancesWithRegions(Arrays.asList(OU_2, OU_3), Arrays.asList(account_1, account_2), INTER, region_3),
+                generateInstancesWithRegions(Arrays.asList(OU_2, OU_3), Arrays.asList(account_1, account_2), INTER, region_2),
+                generateInstancesWithRegions(Arrays.asList(OU_2, OU_3), Arrays.asList(account_1, account_2), INTER, region_1)
+        ));
+        Set<StackInstances> desiredUpdateInstances = new LinkedHashSet<>();
+
+        StackInstancesPlaceHolder placeHolder = new StackInstancesPlaceHolder();
+        AltResourceModelAnalyzer.builder().currentModel(currentModel).build().analyze(placeHolder);
+        Iterator<StackInstances> iterator = desiredCreateInstances.iterator();
+        int index = 0;
+        while (iterator.hasNext()) {
+            StackInstances stackInstances = iterator.next();
+            assertEquals(stackInstances, placeHolder.getCreateStackInstances().get(index));
+            index++;
+        }
+        assertEquals(new LinkedHashSet<>(placeHolder.getDeleteStackInstances()), desiredDeleteInstances);
+        assertEquals(new LinkedHashSet<>(placeHolder.getUpdateStackInstances()), desiredUpdateInstances);
+    }
+
+    @Test
+    public void test_ALT_Create_With_OperationPreferences_And_Region_Order_And_ME() {
+        ResourceModel currentModel = generateModel(new HashSet<>(Collections.singletonList(
+                generateInstancesWithRegions(
+                        Arrays.asList(OU_2, OU_3), Arrays.asList(account_1, account_2), INTER,
+                        new HashSet<>(Arrays.asList(region_1, region_2, region_3)))
+        )));
+        List<String> regionOrder = Arrays.asList(region_3, region_2, region_1);
+        currentModel.setOperationPreferences(new OperationPreferences(null, null, null, null, regionOrder, null));
+        currentModel.setManagedExecution(new ManagedExecution(true));
+
+        Set<StackInstances> desiredDeleteInstances = new LinkedHashSet<>();
+        Set<StackInstances> desiredCreateInstances = new LinkedHashSet<>(Arrays.asList(
+                generateInstancesWithRegions(Arrays.asList(OU_2, OU_3), Arrays.asList(account_1, account_2), INTER, region_3),
+                generateInstancesWithRegions(Arrays.asList(OU_2, OU_3), Arrays.asList(account_1, account_2), INTER, region_2),
+                generateInstancesWithRegions(Arrays.asList(OU_2, OU_3), Arrays.asList(account_1, account_2), INTER, region_1)
+        ));
+        Set<StackInstances> desiredUpdateInstances = new LinkedHashSet<>();
+
+        StackInstancesPlaceHolder placeHolder = new StackInstancesPlaceHolder();
+        AltResourceModelAnalyzer.builder().currentModel(currentModel).build().analyze(placeHolder);
+        Iterator<StackInstances> iterator = desiredCreateInstances.iterator();
+        int index = 0;
+        while (iterator.hasNext()) {
+            StackInstances stackInstances = iterator.next();
+            assertEquals(stackInstances, placeHolder.getCreateStackInstances().get(index));
+            index++;
+        }
+        assertEquals(new LinkedHashSet<>(placeHolder.getDeleteStackInstances()), desiredDeleteInstances);
+        assertEquals(new LinkedHashSet<>(placeHolder.getUpdateStackInstances()), desiredUpdateInstances);
+    }
+
+    @Test
+    public void test_ALT_Create_With_Less_Number_Of_Regions_In_Region_Order() {
+        ResourceModel currentModel = generateModel(new HashSet<>(Collections.singletonList(
+                generateInstancesWithRegions(
+                        Arrays.asList(OU_2, OU_3), Arrays.asList(account_1, account_2), INTER,
+                        new HashSet<>(Arrays.asList(region_1, region_2, region_3)))
+        )));
+        List<String> regionOrder = Arrays.asList(region_3);
+        currentModel.setOperationPreferences(new OperationPreferences(null, null, null, null, regionOrder, null));
+
+        Set<StackInstances> desiredDeleteInstances = new LinkedHashSet<>();
+        Set<StackInstances> desiredCreateInstances = new LinkedHashSet<>(Arrays.asList(
+                generateInstancesWithRegions(Arrays.asList(OU_2, OU_3), Arrays.asList(account_1, account_2), INTER, region_3),
+                generateInstancesWithRegions(Arrays.asList(OU_2, OU_3), Arrays.asList(account_1, account_2), INTER, region_1),
+                generateInstancesWithRegions(Arrays.asList(OU_2, OU_3), Arrays.asList(account_1, account_2), INTER, region_2)
+        ));
+        Set<StackInstances> desiredUpdateInstances = new LinkedHashSet<>();
+
+        StackInstancesPlaceHolder placeHolder = new StackInstancesPlaceHolder();
+        AltResourceModelAnalyzer.builder().currentModel(currentModel).build().analyze(placeHolder);
+        Iterator<StackInstances> iterator = desiredCreateInstances.iterator();
+        int index = 0;
+        while (iterator.hasNext()) {
+            StackInstances stackInstances = iterator.next();
+            assertEquals(stackInstances, placeHolder.getCreateStackInstances().get(index));
+            index++;
+        }
+        assertEquals(new LinkedHashSet<>(placeHolder.getDeleteStackInstances()), desiredDeleteInstances);
+        assertEquals(new LinkedHashSet<>(placeHolder.getUpdateStackInstances()), desiredUpdateInstances);
+    }
+    @Test
+    public void test_ALT_Create_With_InCorrect_Region_Order() {
+        ResourceModel currentModel = generateModel(new HashSet<>(Collections.singletonList(
+                generateInstancesWithRegions(
+                        Arrays.asList(OU_2, OU_3), Arrays.asList(account_1, account_2), INTER,
+                        new HashSet<>(Arrays.asList(region_1, region_2)))
+        )));
+        List<String> regionOrder = Arrays.asList(region_3);
+        currentModel.setOperationPreferences(new OperationPreferences(null, null, null, null, regionOrder, null));
+
+        Set<StackInstances> desiredDeleteInstances = new LinkedHashSet<>();
+        Set<StackInstances> desiredCreateInstances = new LinkedHashSet<>(Arrays.asList(
+                generateInstancesWithRegions(Arrays.asList(OU_2, OU_3), Arrays.asList(account_1, account_2), INTER, region_1),
+                generateInstancesWithRegions(Arrays.asList(OU_2, OU_3), Arrays.asList(account_1, account_2), INTER, region_2)
+        ));
+        Set<StackInstances> desiredUpdateInstances = new LinkedHashSet<>();
+
+        StackInstancesPlaceHolder placeHolder = new StackInstancesPlaceHolder();
+        AltResourceModelAnalyzer.builder().currentModel(currentModel).build().analyze(placeHolder);
+        Iterator<StackInstances> iterator = desiredCreateInstances.iterator();
+        int index = 0;
+        while (iterator.hasNext()) {
+            StackInstances stackInstances = iterator.next();
+            assertEquals(stackInstances, placeHolder.getCreateStackInstances().get(index));
+            index++;
+        }
+        assertEquals(new LinkedHashSet<>(placeHolder.getDeleteStackInstances()), desiredDeleteInstances);
+        assertEquals(new LinkedHashSet<>(placeHolder.getUpdateStackInstances()), desiredUpdateInstances);
+    }
+
+    @Test
+    public void test_ALT_Create_With_Less_Number_Of_Regions() {
+        ResourceModel currentModel = generateModel(new HashSet<>(Collections.singletonList(
+                generateInstancesWithRegions(
+                        Arrays.asList(OU_2, OU_3), Arrays.asList(account_1, account_2), INTER,
+                        new HashSet<>(Arrays.asList(region_1, region_2)))
+        )));
+        List<String> regionOrder = Arrays.asList(region_3, region_2, region_1);
+        currentModel.setOperationPreferences(new OperationPreferences(null, null, null, null, regionOrder, null));
+
+        Set<StackInstances> desiredDeleteInstances = new LinkedHashSet<>();
+        Set<StackInstances> desiredCreateInstances = new LinkedHashSet<>(Arrays.asList(
+                generateInstancesWithRegions(Arrays.asList(OU_2, OU_3), Arrays.asList(account_1, account_2), INTER, region_2),
+                generateInstancesWithRegions(Arrays.asList(OU_2, OU_3), Arrays.asList(account_1, account_2), INTER, region_1)
+        ));
+        Set<StackInstances> desiredUpdateInstances = new LinkedHashSet<>();
+
+        StackInstancesPlaceHolder placeHolder = new StackInstancesPlaceHolder();
+        AltResourceModelAnalyzer.builder().currentModel(currentModel).build().analyze(placeHolder);
+        Iterator<StackInstances> iterator = desiredCreateInstances.iterator();
+        int index = 0;
+        while (iterator.hasNext()) {
+            StackInstances stackInstances = iterator.next();
+            assertEquals(stackInstances, placeHolder.getCreateStackInstances().get(index));
+            index++;
+        }
+        assertEquals(new LinkedHashSet<>(placeHolder.getDeleteStackInstances()), desiredDeleteInstances);
+        assertEquals(new LinkedHashSet<>(placeHolder.getUpdateStackInstances()), desiredUpdateInstances);
+    }
+
+    @Test
+    public void test_ALT_Delete_With_OperationPreferences_And_Region_Order() {
+        ResourceModel previousModel = generateModel(new HashSet<>(Collections.singletonList(
+                generateInstancesWithRegions(
+                        Arrays.asList(OU_2, OU_3), Arrays.asList(account_1, account_2), INTER,
+                        new HashSet<>(Arrays.asList(region_1, region_2, region_3)))
+        )));
+        List<String> regionOrder = Arrays.asList(region_3, region_2, region_1);
+        previousModel.setOperationPreferences(new OperationPreferences(null, null, null, null, regionOrder, null));
+
+        Set<StackInstances> desiredDeleteInstances = new LinkedHashSet<>(Arrays.asList(
+                generateInstancesWithRegions(Arrays.asList(OU_2, OU_3), Arrays.asList(account_1, account_2), INTER, region_3),
+                generateInstancesWithRegions(Arrays.asList(OU_2, OU_3), Arrays.asList(account_1, account_2), INTER, region_2),
+                generateInstancesWithRegions(Arrays.asList(OU_2, OU_3), Arrays.asList(account_1, account_2), INTER, region_1)
+        ));
+        Set<StackInstances> desiredCreateInstances = new LinkedHashSet<>();
+        Set<StackInstances> desiredUpdateInstances = new LinkedHashSet<>();
+
+        StackInstancesPlaceHolder placeHolder = new StackInstancesPlaceHolder();
+        AltResourceModelAnalyzer.builder().previousModel(previousModel).build().analyze(placeHolder);
+
+        Iterator<StackInstances> iterator = desiredDeleteInstances.iterator();
+        int index = 0;
+        while (iterator.hasNext()) {
+            StackInstances stackInstances = iterator.next();
+            assertEquals(stackInstances, placeHolder.getDeleteStackInstances().get(index));
+            index++;
+        }
+        assertEquals(new LinkedHashSet<>(placeHolder.getCreateStackInstances()), desiredCreateInstances);
+        assertEquals(new LinkedHashSet<>(placeHolder.getUpdateStackInstances()), desiredUpdateInstances);
+    }
+
+    @Test
+    public void test_ALT_Create_With_Null_Region_Order_And_Null_OperationPreferences() {
+        ResourceModel currentModel = generateModel(new HashSet<>(Collections.singletonList(
+                generateInstancesWithRegions(
+                        Arrays.asList(OU_2, OU_3), Arrays.asList(account_1, account_2), INTER,
+                        new HashSet<>(Arrays.asList(region_1, region_2, region_3)))
+        )));
+
+        Set<StackInstances> desiredDeleteInstances = new LinkedHashSet<>();
+        Set<StackInstances> desiredCreateInstances = new LinkedHashSet<>(Arrays.asList(
+                generateInstancesWithRegions(Arrays.asList(OU_2, OU_3), Arrays.asList(account_1, account_2), INTER, region_1),
+                generateInstancesWithRegions(Arrays.asList(OU_2, OU_3), Arrays.asList(account_1, account_2), INTER, region_2),
+                generateInstancesWithRegions(Arrays.asList(OU_2, OU_3), Arrays.asList(account_1, account_2), INTER, region_3)
+        ));
+        Set<StackInstances> desiredUpdateInstances = new LinkedHashSet<>();
+
+        StackInstancesPlaceHolder placeHolder = new StackInstancesPlaceHolder();
+        AltResourceModelAnalyzer.builder().currentModel(currentModel).build().analyze(placeHolder);
+
+        assertEquals(new LinkedHashSet<>(placeHolder.getDeleteStackInstances()), desiredDeleteInstances);
+        assertEquals(new LinkedHashSet<>(placeHolder.getCreateStackInstances()), desiredCreateInstances);
+        assertEquals(new LinkedHashSet<>(placeHolder.getUpdateStackInstances()), desiredUpdateInstances);
+    }
+
+    @Test
+    public void test_ALT_Create_With_Null_Region_Order_And_Not_Null_OperationPreferences() {
+        ResourceModel currentModel = generateModel(new HashSet<>(Collections.singletonList(
+                generateInstancesWithRegions(
+                        Arrays.asList(OU_2, OU_3), Arrays.asList(account_1, account_2), INTER,
+                        new HashSet<>(Arrays.asList(region_1, region_2, region_3)))
+        )));
+        currentModel.setOperationPreferences(new OperationPreferences(null, null, null, null, null, null));
+
+        Set<StackInstances> desiredDeleteInstances = new LinkedHashSet<>();
+        Set<StackInstances> desiredCreateInstances = new LinkedHashSet<>(Arrays.asList(
+                generateInstancesWithRegions(Arrays.asList(OU_2, OU_3), Arrays.asList(account_1, account_2), INTER, region_1),
+                generateInstancesWithRegions(Arrays.asList(OU_2, OU_3), Arrays.asList(account_1, account_2), INTER, region_2),
+                generateInstancesWithRegions(Arrays.asList(OU_2, OU_3), Arrays.asList(account_1, account_2), INTER, region_3)
+        ));
+        Set<StackInstances> desiredUpdateInstances = new LinkedHashSet<>();
+
+        StackInstancesPlaceHolder placeHolder = new StackInstancesPlaceHolder();
+        AltResourceModelAnalyzer.builder().currentModel(currentModel).build().analyze(placeHolder);
+
+        assertEquals(new LinkedHashSet<>(placeHolder.getDeleteStackInstances()), desiredDeleteInstances);
+        assertEquals(new LinkedHashSet<>(placeHolder.getCreateStackInstances()), desiredCreateInstances);
+        assertEquals(new LinkedHashSet<>(placeHolder.getUpdateStackInstances()), desiredUpdateInstances);
+    }
+
+    @Test
+    public void test_ALT_Delete_With_Null_Region_Order_And_Not_Null_OperationPreferences() {
+        ResourceModel previousModel = generateModel(new HashSet<>(Collections.singletonList(
+                generateInstancesWithRegions(
+                        Arrays.asList(OU_2, OU_3), Arrays.asList(account_1, account_2), INTER,
+                        new HashSet<>(Arrays.asList(region_1, region_2, region_3)))
+        )));
+        previousModel.setOperationPreferences(new OperationPreferences(null, null, null, null, null, null));
+
+        Set<StackInstances> desiredCreateInstances = new LinkedHashSet<>();
+        Set<StackInstances> desiredDeleteInstances = new LinkedHashSet<>(Arrays.asList(
+                generateInstancesWithRegions(Arrays.asList(OU_2, OU_3), Arrays.asList(account_1, account_2), INTER, region_1),
+                generateInstancesWithRegions(Arrays.asList(OU_2, OU_3), Arrays.asList(account_1, account_2), INTER, region_2),
+                generateInstancesWithRegions(Arrays.asList(OU_2, OU_3), Arrays.asList(account_1, account_2), INTER, region_3)
+        ));
+        Set<StackInstances> desiredUpdateInstances = new LinkedHashSet<>();
+
+        StackInstancesPlaceHolder placeHolder = new StackInstancesPlaceHolder();
+        AltResourceModelAnalyzer.builder().previousModel(previousModel).build().analyze(placeHolder);
+
+        assertEquals(new LinkedHashSet<>(placeHolder.getDeleteStackInstances()), desiredDeleteInstances);
+        assertEquals(new LinkedHashSet<>(placeHolder.getCreateStackInstances()), desiredCreateInstances);
+        assertEquals(new LinkedHashSet<>(placeHolder.getUpdateStackInstances()), desiredUpdateInstances);
+    }
+
+    @Test
+    public void test_ALT_Delete_With_Null_Region_Order_And_Null_OperationPreferences() {
+        ResourceModel previousModel = generateModel(new HashSet<>(Collections.singletonList(
+                generateInstancesWithRegions(
+                        Arrays.asList(OU_2, OU_3), Arrays.asList(account_1, account_2), INTER,
+                        new HashSet<>(Arrays.asList(region_1, region_2, region_3)))
+        )));
+
+        Set<StackInstances> desiredDeleteInstances = new LinkedHashSet<>(Arrays.asList(
+                generateInstancesWithRegions(Arrays.asList(OU_2, OU_3), Arrays.asList(account_1, account_2), INTER, region_1),
+                generateInstancesWithRegions(Arrays.asList(OU_2, OU_3), Arrays.asList(account_1, account_2), INTER, region_2),
+                generateInstancesWithRegions(Arrays.asList(OU_2, OU_3), Arrays.asList(account_1, account_2), INTER, region_3)
+        ));
+        Set<StackInstances> desiredCreateInstances = new LinkedHashSet<>();
+        Set<StackInstances> desiredUpdateInstances = new LinkedHashSet<>();
+
+        StackInstancesPlaceHolder placeHolder = new StackInstancesPlaceHolder();
+        AltResourceModelAnalyzer.builder().previousModel(previousModel).build().analyze(placeHolder);
+
+        assertEquals(new LinkedHashSet<>(placeHolder.getDeleteStackInstances()), desiredDeleteInstances);
+        assertEquals(new LinkedHashSet<>(placeHolder.getCreateStackInstances()), desiredCreateInstances);
+        assertEquals(new LinkedHashSet<>(placeHolder.getUpdateStackInstances()), desiredUpdateInstances);
+    }
+
+    @Test
+    public void test_ALT_Update_With_Null_Region_Order() {
+        ResourceModel previousModel = generateModel(new HashSet<>(Collections.singletonList(
+                generateInstancesWithRegions(
+                        Arrays.asList(OU_2, OU_3), Arrays.asList(account_1, account_2), INTER,
+                        new HashSet<>(Arrays.asList(region_1, region_2, region_3)))
+        )));
+
+        ResourceModel currentModel = generateModel(new HashSet<>(Collections.singletonList(
+                generateInstancesWithRegions(
+                        Arrays.asList(OU_2, OU_3), Arrays.asList(account_1, account_2), INTER,
+                        new HashSet<>(Arrays.asList(region_1, region_2, region_4)))
+        )));
+
+        Set<StackInstances> desiredDeleteInstances = new LinkedHashSet<>(Collections.singletonList(
+                generateInstancesWithRegions(Arrays.asList(OU_2, OU_3), Arrays.asList(account_1, account_2), INTER, region_3)
+        ));
+        Set<StackInstances> desiredCreateInstances = new LinkedHashSet<>(Collections.singletonList(
+                generateInstancesWithRegions(Arrays.asList(OU_2, OU_3), Arrays.asList(account_1, account_2), INTER, region_4)
+        ));
+        Set<StackInstances> desiredUpdateInstances = new LinkedHashSet<>(Arrays.asList(
+                generateInstancesWithRegions(Collections.singletonList(OU_3), Arrays.asList(account_1, account_2), INTER, region_1),
+                generateInstancesWithRegions(Collections.singletonList(OU_2), Arrays.asList(account_1, account_2), INTER, region_1),
+                generateInstancesWithRegions(Collections.singletonList(OU_3), Arrays.asList(account_1, account_2), INTER, region_2),
+                generateInstancesWithRegions(Collections.singletonList(OU_2), Arrays.asList(account_1, account_2), INTER, region_2)
+        ));
+
+        StackInstancesPlaceHolder placeHolder = new StackInstancesPlaceHolder();
+        AltResourceModelAnalyzer.builder().previousModel(previousModel).currentModel(currentModel).build().analyze(placeHolder);
+
+        assertEquals(new LinkedHashSet<>(placeHolder.getDeleteStackInstances()), desiredDeleteInstances);
+        assertEquals(new LinkedHashSet<>(placeHolder.getCreateStackInstances()), desiredCreateInstances);
+        assertEquals(new LinkedHashSet<>(placeHolder.getUpdateStackInstances()), desiredUpdateInstances);
+    }
+
+    @Test
+    public void test_ALT_Update_With_Region_Order() {
+        ResourceModel previousModel = generateModel(new HashSet<>(Collections.singletonList(
+                generateInstancesWithRegions(
+                        Arrays.asList(OU_2, OU_3), Arrays.asList(account_1, account_2), INTER,
+                        new HashSet<>(Arrays.asList(region_1, region_2, region_3)))
+        )));
+
+        ResourceModel currentModel = generateModel(new HashSet<>(Collections.singletonList(
+                generateInstancesWithRegions(
+                        Arrays.asList(OU_2, OU_3), Arrays.asList(account_1, account_2), INTER,
+                        new HashSet<>(Arrays.asList(region_1, region_2, region_4)))
+        )));
+        List<String> regionOrder = Arrays.asList(region_4, region_3, region_2, region_1);
+        OperationPreferences operationPreferences = new OperationPreferences(null, null, null, null, regionOrder, null);
+        currentModel.setOperationPreferences(operationPreferences);
+        previousModel.setOperationPreferences(operationPreferences);
+
+        Set<StackInstances> desiredDeleteInstances = new LinkedHashSet<>(Collections.singletonList(
+                generateInstancesWithRegions(Arrays.asList(OU_2, OU_3), Arrays.asList(account_1, account_2), INTER, region_3)
+        ));
+        Set<StackInstances> desiredCreateInstances = new LinkedHashSet<>(Collections.singletonList(
+                generateInstancesWithRegions(Arrays.asList(OU_2, OU_3), Arrays.asList(account_1, account_2), INTER, region_4)
+        ));
+        Set<StackInstances> desiredUpdateInstances = new LinkedHashSet<>(Arrays.asList(
+                generateInstancesWithRegions(Collections.singletonList(OU_3), Arrays.asList(account_1, account_2), INTER, region_2),
+                generateInstancesWithRegions(Collections.singletonList(OU_2), Arrays.asList(account_1, account_2), INTER, region_2),
+                generateInstancesWithRegions(Collections.singletonList(OU_3), Arrays.asList(account_1, account_2), INTER, region_1),
+                generateInstancesWithRegions(Collections.singletonList(OU_2), Arrays.asList(account_1, account_2), INTER, region_1)
+        ));
+
+        StackInstancesPlaceHolder placeHolder = new StackInstancesPlaceHolder();
+        AltResourceModelAnalyzer.builder().previousModel(previousModel).currentModel(currentModel).build().analyze(placeHolder);
+
+        Iterator<StackInstances> iterator = desiredCreateInstances.iterator();
+
+        int index = 0;
+        while (iterator.hasNext()) {
+            StackInstances stackInstances = iterator.next();
+            assertEquals(stackInstances, placeHolder.getCreateStackInstances().get(index));
+            index++;
+        }
+        iterator = desiredDeleteInstances.iterator();
+        index = 0;
+        while (iterator.hasNext()) {
+            StackInstances stackInstances = iterator.next();
+            assertEquals(stackInstances, placeHolder.getDeleteStackInstances().get(index));
+            index++;
+        }
+
+        iterator = desiredUpdateInstances.iterator();
+        index = 0;
+        while (iterator.hasNext()) {
+            StackInstances stackInstances = iterator.next();
+            assertEquals(stackInstances, placeHolder.getUpdateStackInstances().get(index));
+            index++;
+        }
     }
 
     @Test
@@ -165,15 +548,15 @@ public class AltResourceModelAnalyzerTest {
                 generateInstancesWithRegions(Arrays.asList(OU_3, OU_4), region_4)
         )));
 
-        Set<StackInstances> desiredDeleteInstances = new HashSet<>(Arrays.asList(
+        Set<StackInstances> desiredDeleteInstances = new LinkedHashSet<>(Arrays.asList(
                 generateInstancesWithRegions(Arrays.asList(OU_2, OU_3), region_3),
                 generateDeleteInstances(OU_2, Collections.emptyList(), NONE, region_1),
                 generateDeleteInstances(OU_2, Collections.emptyList(), NONE, region_2)
         ));
-        Set<StackInstances> desiredCreateInstances = new HashSet<>(Arrays.asList(
+        Set<StackInstances> desiredCreateInstances = new LinkedHashSet<>(Arrays.asList(
                 generateInstancesWithRegions(Arrays.asList(OU_3, OU_4), region_4)
         ));
-        Set<StackInstances> desiredUpdateInstances = new HashSet<>(Arrays.asList(
+        Set<StackInstances> desiredUpdateInstances = new LinkedHashSet<>(Arrays.asList(
                 generateInstancesWithRegions(OU_1, Collections.emptyList(), NONE, region_1),
                 generateInstancesWithRegions(OU_1, Collections.emptyList(), NONE, region_2)
         ));
@@ -181,9 +564,9 @@ public class AltResourceModelAnalyzerTest {
         StackInstancesPlaceHolder placeHolder = new StackInstancesPlaceHolder();
         AltResourceModelAnalyzer.builder().currentModel(currentModel).previousModel(previousModel).build().analyze(placeHolder);
 
-        assertThat(Comparator.equals(new HashSet<>(placeHolder.getDeleteStackInstances()), desiredDeleteInstances)).isTrue();
-        assertThat(Comparator.equals(new HashSet<>(placeHolder.getCreateStackInstances()), desiredCreateInstances)).isTrue();
-        assertThat(Comparator.equals(new HashSet<>(placeHolder.getUpdateStackInstances()), desiredUpdateInstances)).isTrue();
+        assertThat(Comparator.equals(new LinkedHashSet<>(placeHolder.getDeleteStackInstances()), desiredDeleteInstances)).isTrue();
+        assertThat(Comparator.equals(new LinkedHashSet<>(placeHolder.getCreateStackInstances()), desiredCreateInstances)).isTrue();
+        assertThat(Comparator.equals(new LinkedHashSet<>(placeHolder.getUpdateStackInstances()), desiredUpdateInstances)).isTrue();
     }
 
     @Test
@@ -197,25 +580,25 @@ public class AltResourceModelAnalyzerTest {
                         new HashSet<>(Arrays.asList(region_2, region_3)))
         )));
 
-        Set<StackInstances> desiredDeleteInstances = new HashSet<>(Arrays.asList(
+        Set<StackInstances> desiredDeleteInstances = new LinkedHashSet<>(Arrays.asList(
                 generateInstancesWithRegions(Arrays.asList(OU_1, OU_2), region_1),
                 generateDeleteInstances(OU_1, Collections.emptyList(), NONE, region_2),
                 generateDeleteInstances(OU_2, Arrays.asList(account_2, account_3), DIFF, region_2)
         ));
-        Set<StackInstances> desiredCreateInstances = new HashSet<>(Arrays.asList(
+        Set<StackInstances> desiredCreateInstances = new LinkedHashSet<>(Arrays.asList(
                 generateInstancesWithRegions(Arrays.asList(OU_2, OU_3), Arrays.asList(account_2, account_3), INTER, region_3),
                 generateInstancesWithRegions(OU_3, Arrays.asList(account_2, account_3), INTER, region_2)
         ));
-        Set<StackInstances> desiredUpdateInstances = new HashSet<>(Arrays.asList(
+        Set<StackInstances> desiredUpdateInstances = new LinkedHashSet<>(Arrays.asList(
                 generateInstancesWithRegions(OU_2, Arrays.asList(account_2, account_3), INTER, region_2)
         ));
 
         StackInstancesPlaceHolder placeHolder = new StackInstancesPlaceHolder();
         AltResourceModelAnalyzer.builder().currentModel(currentModel).previousModel(previousModel).build().analyze(placeHolder);
 
-        assertThat(Comparator.equals(new HashSet<>(placeHolder.getDeleteStackInstances()), desiredDeleteInstances)).isTrue();
-        assertThat(Comparator.equals(new HashSet<>(placeHolder.getCreateStackInstances()), desiredCreateInstances)).isTrue();
-        assertThat(Comparator.equals(new HashSet<>(placeHolder.getUpdateStackInstances()), desiredUpdateInstances)).isTrue();
+        assertThat(Comparator.equals(new LinkedHashSet<>(placeHolder.getDeleteStackInstances()), desiredDeleteInstances)).isTrue();
+        assertThat(Comparator.equals(new LinkedHashSet<>(placeHolder.getCreateStackInstances()), desiredCreateInstances)).isTrue();
+        assertThat(Comparator.equals(new LinkedHashSet<>(placeHolder.getUpdateStackInstances()), desiredUpdateInstances)).isTrue();
     }
 
     @Test
@@ -229,25 +612,25 @@ public class AltResourceModelAnalyzerTest {
                         new HashSet<>(Arrays.asList(region_1, region_2)))
         )));
 
-        Set<StackInstances> desiredDeleteInstances = new HashSet<>(Arrays.asList(
+        Set<StackInstances> desiredDeleteInstances = new LinkedHashSet<>(Arrays.asList(
                 generateInstancesWithRegions(Arrays.asList(OU_2, OU_3), Arrays.asList(account_2, account_3), INTER, region_3),
                 generateDeleteInstances(OU_3, Arrays.asList(account_2, account_3), INTER, region_2)
         ));
-        Set<StackInstances> desiredCreateInstances = new HashSet<>(Arrays.asList(
+        Set<StackInstances> desiredCreateInstances = new LinkedHashSet<>(Arrays.asList(
                 generateInstancesWithRegions(Arrays.asList(OU_1, OU_2), region_1),
                 generateInstancesWithRegions(OU_1, Collections.emptyList(), NONE, region_2),
                 generateInstancesWithRegions(OU_2, Arrays.asList(account_2, account_3), DIFF, region_2)
         ));
-        Set<StackInstances> desiredUpdateInstances = new HashSet<>(Arrays.asList(
+        Set<StackInstances> desiredUpdateInstances = new LinkedHashSet<>(Arrays.asList(
                 generateInstancesWithRegions(OU_2, Arrays.asList(account_2, account_3), INTER, region_2)
         ));
 
         StackInstancesPlaceHolder placeHolder = new StackInstancesPlaceHolder();
         AltResourceModelAnalyzer.builder().currentModel(currentModel).previousModel(previousModel).build().analyze(placeHolder);
 
-        assertThat(Comparator.equals(new HashSet<>(placeHolder.getDeleteStackInstances()), desiredDeleteInstances)).isTrue();
-        assertThat(Comparator.equals(new HashSet<>(placeHolder.getCreateStackInstances()), desiredCreateInstances)).isTrue();
-        assertThat(Comparator.equals(new HashSet<>(placeHolder.getUpdateStackInstances()), desiredUpdateInstances)).isTrue();
+        assertThat(Comparator.equals(new LinkedHashSet<>(placeHolder.getDeleteStackInstances()), desiredDeleteInstances)).isTrue();
+        assertThat(Comparator.equals(new LinkedHashSet<>(placeHolder.getCreateStackInstances()), desiredCreateInstances)).isTrue();
+        assertThat(Comparator.equals(new LinkedHashSet<>(placeHolder.getUpdateStackInstances()), desiredUpdateInstances)).isTrue();
     }
 
     @Test
@@ -261,25 +644,25 @@ public class AltResourceModelAnalyzerTest {
                         new HashSet<>(Arrays.asList(region_2, region_3)))
         )));
 
-        Set<StackInstances> desiredDeleteInstances = new HashSet<>(Arrays.asList(
+        Set<StackInstances> desiredDeleteInstances = new LinkedHashSet<>(Arrays.asList(
                 generateInstancesWithRegions(OU_1, Arrays.asList(account_1, account_2), DIFF, region_1),
                 generateDeleteInstances(OU_1, Arrays.asList(account_1, account_2, account_3), DIFF, region_2)
 
         ));
-        Set<StackInstances> desiredCreateInstances = new HashSet<>(Arrays.asList(
+        Set<StackInstances> desiredCreateInstances = new LinkedHashSet<>(Arrays.asList(
                 generateInstancesWithRegions(OU_1, Arrays.asList(account_2, account_3), INTER, region_3),
                 generateInstancesWithRegions(OU_1, Collections.singletonList(account_2), INTER, region_2)
         ));
-        Set<StackInstances> desiredUpdateInstances = new HashSet<>(Arrays.asList(
+        Set<StackInstances> desiredUpdateInstances = new LinkedHashSet<>(Arrays.asList(
                 generateInstancesWithRegions(OU_1, Collections.singletonList(account_3), INTER, region_2)
         ));
 
         StackInstancesPlaceHolder placeHolder = new StackInstancesPlaceHolder();
         AltResourceModelAnalyzer.builder().currentModel(currentModel).previousModel(previousModel).build().analyze(placeHolder);
 
-        assertThat(Comparator.equals(new HashSet<>(placeHolder.getDeleteStackInstances()), desiredDeleteInstances)).isTrue();
-        assertThat(Comparator.equals(new HashSet<>(placeHolder.getCreateStackInstances()), desiredCreateInstances)).isTrue();
-        assertThat(Comparator.equals(new HashSet<>(placeHolder.getUpdateStackInstances()), desiredUpdateInstances)).isTrue();
+        assertThat(Comparator.equals(new LinkedHashSet<>(placeHolder.getDeleteStackInstances()), desiredDeleteInstances)).isTrue();
+        assertThat(Comparator.equals(new LinkedHashSet<>(placeHolder.getCreateStackInstances()), desiredCreateInstances)).isTrue();
+        assertThat(Comparator.equals(new LinkedHashSet<>(placeHolder.getUpdateStackInstances()), desiredUpdateInstances)).isTrue();
     }
 
     @Test


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Adding changes to handle region order for ALT operations. Currently, we don't batch operations for ALT, as a result ALT operations don't follow region order. Batching operations will be the long term solution for this. I have created this solution as a short term fix
- Changed Hashmap to LinkedHashmap to maintain region order, same with HashSet(Changed it to LinkedHashSet to maintain the order of Stack Instances)
- The average time complexity for LinkedHashmap/HashSet v Hashmap/HashSet and  for Insert, Delete, Search is the same -> O(1)
- The worst time complexity for LinkedHashmap/HashSet v Hashmap/HashSet for Insert, Delete, Search is the same -> O(n)
- Manually tested the solution in my dev account

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
