### PR TITLE
[StackSets] Add stack set name as an additional identifier; return AlreadyExists exception for duplicate resources

### DIFF
--- a/aws-cloudformation-stackset/aws-cloudformation-stackset.json
+++ b/aws-cloudformation-stackset/aws-cloudformation-stackset.json
@@ -346,6 +346,7 @@
   "writeOnlyProperties": [
     "/properties/TemplateURL",
     "/properties/OperationPreferences",
+    "/properties/StackInstancesGroup",
     "/properties/CallAs"
   ],
   "readOnlyProperties": [
@@ -353,6 +354,11 @@
   ],
   "primaryIdentifier": [
     "/properties/StackSetId"
+  ],
+  "additionalIdentifiers": [
+    [
+      "/properties/StackSetName"
+    ]
   ],
   "handlers": {
     "create": {

--- a/aws-cloudformation-stackset/src/main/java/software/amazon/cloudformation/stackset/CreateHandler.java
+++ b/aws-cloudformation-stackset/src/main/java/software/amazon/cloudformation/stackset/CreateHandler.java
@@ -5,11 +5,8 @@ import software.amazon.awssdk.services.cloudformation.model.CreateStackSetReques
 import software.amazon.awssdk.services.cloudformation.model.CreateStackSetResponse;
 import software.amazon.awssdk.services.cloudformation.model.NameAlreadyExistsException;
 import software.amazon.cloudformation.Action;
-import software.amazon.cloudformation.exceptions.BaseHandlerException;
 import software.amazon.cloudformation.exceptions.CfnAlreadyExistsException;
-import software.amazon.cloudformation.exceptions.CfnGeneralServiceException;
 import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
-import software.amazon.cloudformation.proxy.HandlerErrorCode;
 import software.amazon.cloudformation.proxy.Logger;
 import software.amazon.cloudformation.proxy.ProgressEvent;
 import software.amazon.cloudformation.proxy.ProxyClient;

--- a/aws-cloudformation-stackset/src/main/java/software/amazon/cloudformation/stackset/CreateHandler.java
+++ b/aws-cloudformation-stackset/src/main/java/software/amazon/cloudformation/stackset/CreateHandler.java
@@ -1,9 +1,15 @@
 package software.amazon.cloudformation.stackset;
 
 import software.amazon.awssdk.services.cloudformation.CloudFormationClient;
+import software.amazon.awssdk.services.cloudformation.model.CreateStackSetRequest;
 import software.amazon.awssdk.services.cloudformation.model.CreateStackSetResponse;
+import software.amazon.awssdk.services.cloudformation.model.NameAlreadyExistsException;
 import software.amazon.cloudformation.Action;
+import software.amazon.cloudformation.exceptions.BaseHandlerException;
+import software.amazon.cloudformation.exceptions.CfnAlreadyExistsException;
+import software.amazon.cloudformation.exceptions.CfnGeneralServiceException;
 import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
+import software.amazon.cloudformation.proxy.HandlerErrorCode;
 import software.amazon.cloudformation.proxy.Logger;
 import software.amazon.cloudformation.proxy.ProgressEvent;
 import software.amazon.cloudformation.proxy.ProxyClient;
@@ -38,8 +44,21 @@ public class CreateHandler extends BaseHandlerStd {
                     logger.log(String.format("%s [%s] StackSet creation succeeded", ResourceModel.TYPE_NAME, model.getStackSetId()));
                     return response;
                 })
+                .handleError(this::handleCreateError)
                 .progress()
                 .then(progress -> createStackInstances(proxy, proxyClient, progress, placeHolder.getCreateStackInstances(), logger))
                 .then(progress -> ProgressEvent.defaultSuccessHandler(model));
+    }
+
+    public ProgressEvent<ResourceModel, CallbackContext> handleCreateError(CreateStackSetRequest request,
+                                                                           Exception exception,
+                                                                           ProxyClient<CloudFormationClient> client,
+                                                                           ResourceModel model,
+                                                                           CallbackContext callbackContext) throws Exception {
+        if (exception instanceof NameAlreadyExistsException) {
+            CfnAlreadyExistsException mappedException = new CfnAlreadyExistsException(ResourceModel.TYPE_NAME, model.getStackSetName(), exception);
+            return ProgressEvent.failed(model, callbackContext, mappedException.getErrorCode(), mappedException.getMessage());
+        }
+        throw exception;
     }
 }

--- a/aws-cloudformation-stackset/src/test/java/software/amazon/cloudformation/stackset/util/TestUtils.java
+++ b/aws-cloudformation-stackset/src/test/java/software/amazon/cloudformation/stackset/util/TestUtils.java
@@ -495,6 +495,7 @@ public class TestUtils {
             .build();
 
     public final static ResourceModel SELF_MANAGED_MODEL = ResourceModel.builder()
+            .stackSetName(STACK_SET_NAME)
             .stackSetId(STACK_SET_ID)
             .permissionModel(SELF_MANAGED)
             .capabilities(CAPABILITIES)


### PR DESCRIPTION
- Add stack set name as an additional identifier, as it can be used along with stack set id in all APIs
- Return AlreadyExists exception for duplicate resources, required as part of the CREATE handler contract

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
