### PR TITLE
Add ConcurrencyMode Support for StackSet Resource

### DIFF
--- a/aws-cloudformation-hookdefaultversion/pom.xml
+++ b/aws-cloudformation-hookdefaultversion/pom.xml
@@ -35,7 +35,7 @@
         <dependency>
             <groupId>software.amazon.cloudformation</groupId>
             <artifactId>aws-cloudformation-rpdk-java-plugin</artifactId>
-            <version>[2.0.0, 3.0.0)</version>
+            <version>[2.0.0, 2.1.0)</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/org.projectlombok/lombok -->
         <dependency>

--- a/aws-cloudformation-hooktypeconfig/pom.xml
+++ b/aws-cloudformation-hooktypeconfig/pom.xml
@@ -35,7 +35,7 @@
         <dependency>
             <groupId>software.amazon.cloudformation</groupId>
             <artifactId>aws-cloudformation-rpdk-java-plugin</artifactId>
-            <version>[2.0.0, 3.0.0)</version>
+            <version>[2.0.0, 2.1.0)</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/org.projectlombok/lombok -->
         <dependency>

--- a/aws-cloudformation-hookversion/pom.xml
+++ b/aws-cloudformation-hookversion/pom.xml
@@ -35,7 +35,7 @@
         <dependency>
             <groupId>software.amazon.cloudformation</groupId>
             <artifactId>aws-cloudformation-rpdk-java-plugin</artifactId>
-            <version>[2.0.0,3.0.0)</version>
+            <version>[2.0.0,2.1.0)</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/org.projectlombok/lombok -->
         <dependency>

--- a/aws-cloudformation-stack/pom.xml
+++ b/aws-cloudformation-stack/pom.xml
@@ -30,7 +30,7 @@
         <dependency>
             <groupId>software.amazon.cloudformation</groupId>
             <artifactId>aws-cloudformation-rpdk-java-plugin</artifactId>
-            <version>[2.0.0,3.0.0)</version>
+            <version>[2.0.0,2.1.0)</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/org.projectlombok/lombok -->
         <dependency>

--- a/aws-cloudformation-stackset/aws-cloudformation-stackset.json
+++ b/aws-cloudformation-stackset/aws-cloudformation-stackset.json
@@ -76,6 +76,14 @@
         "PARALLEL"
       ]
     },
+    "ConcurrencyMode": {
+      "description": "Specifies how the concurrency level behaves during the operation execution.",
+      "type": "string",
+      "enum": [
+        "STRICT_FAILURE_TOLERANCE",
+        "SOFT_FAILURE_TOLERANCE"
+      ]
+    },
     "Active": {
       "description": "When true, StackSets performs non-conflicting operations concurrently and queues conflicting operations. After conflicting operations finish, StackSets starts queued operations in request order.",
       "type": "boolean"
@@ -110,6 +118,9 @@
         },
         "RegionConcurrencyType": {
           "$ref": "#/definitions/RegionConcurrencyType"
+        },
+        "ConcurrencyMode": {
+          "$ref": "#/definitions/ConcurrencyMode"
         }
       },
       "additionalProperties": false

--- a/aws-cloudformation-stackset/docs/operationpreferences.md
+++ b/aws-cloudformation-stackset/docs/operationpreferences.md
@@ -15,7 +15,8 @@ To declare this entity in your AWS CloudFormation template, use the following sy
     "<a href="#maxconcurrentcount" title="MaxConcurrentCount">MaxConcurrentCount</a>" : <i>Integer</i>,
     "<a href="#maxconcurrentpercentage" title="MaxConcurrentPercentage">MaxConcurrentPercentage</a>" : <i>Integer</i>,
     "<a href="#regionorder" title="RegionOrder">RegionOrder</a>" : <i>[ String, ... ]</i>,
-    "<a href="#regionconcurrencytype" title="RegionConcurrencyType">RegionConcurrencyType</a>" : <i>String</i>
+    "<a href="#regionconcurrencytype" title="RegionConcurrencyType">RegionConcurrencyType</a>" : <i>String</i>,
+    "<a href="#concurrencymode" title="ConcurrencyMode">ConcurrencyMode</a>" : <i>String</i>
 }
 </pre>
 
@@ -29,6 +30,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 <a href="#regionorder" title="RegionOrder">RegionOrder</a>: <i>
       - String</i>
 <a href="#regionconcurrencytype" title="RegionConcurrencyType">RegionConcurrencyType</a>: <i>String</i>
+<a href="#concurrencymode" title="ConcurrencyMode">ConcurrencyMode</a>: <i>String</i>
 </pre>
 
 ## Properties
@@ -82,5 +84,17 @@ _Required_: No
 _Type_: String
 
 _Allowed Values_: <code>SEQUENTIAL</code> | <code>PARALLEL</code>
+
+_Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
+
+#### ConcurrencyMode
+
+Specifies how the concurrency level behaves during the operation execution.
+
+_Required_: No
+
+_Type_: String
+
+_Allowed Values_: <code>STRICT_FAILURE_TOLERANCE</code> | <code>SOFT_FAILURE_TOLERANCE</code>
 
 _Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)

--- a/aws-cloudformation-stackset/pom.xml
+++ b/aws-cloudformation-stackset/pom.xml
@@ -24,7 +24,7 @@
             <dependency>
                 <groupId>software.amazon.awssdk</groupId>
                 <artifactId>bom</artifactId>
-                <version>2.17.235</version>
+                <version>2.25.51</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -49,7 +49,7 @@
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>cloudformation</artifactId>
             <!-- Specify the version id so we can install local sdk -->
-            <version>2.17.235</version>
+            <version>2.25.51</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/org.projectlombok/lombok -->
         <dependency>

--- a/aws-cloudformation-stackset/src/main/java/software/amazon/cloudformation/stackset/translator/PropertyTranslator.java
+++ b/aws-cloudformation-stackset/src/main/java/software/amazon/cloudformation/stackset/translator/PropertyTranslator.java
@@ -118,6 +118,7 @@ public class PropertyTranslator {
                 .failureTolerancePercentage(operationPreferences.getFailureTolerancePercentage())
                 .regionOrder(operationPreferences.getRegionOrder())
                 .regionConcurrencyType(operationPreferences.getRegionConcurrencyType())
+                .concurrencyMode(operationPreferences.getConcurrencyMode())
                 .build();
     }
 

--- a/aws-cloudformation-stackset/src/test/java/software/amazon/cloudformation/stackset/translator/PropertyTranslatorTest.java
+++ b/aws-cloudformation-stackset/src/test/java/software/amazon/cloudformation/stackset/translator/PropertyTranslatorTest.java
@@ -2,6 +2,7 @@ package software.amazon.cloudformation.stackset.translator;
 
 import java.util.HashSet;
 import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.services.cloudformation.model.ConcurrencyMode;
 import software.amazon.awssdk.services.cloudformation.model.DeploymentTargets;
 import software.amazon.awssdk.services.cloudformation.model.RegionConcurrencyType;
 import software.amazon.awssdk.services.cloudformation.model.StackSetOperationPreferences;
@@ -73,6 +74,7 @@ public class PropertyTranslatorTest {
         assertThat(stackSetOperationPreferences.maxConcurrentPercentage()).isEqualTo(100);
         assertThat(stackSetOperationPreferences.regionOrder()).isEqualTo(Arrays.asList(TestUtils.US_WEST_1, TestUtils.US_EAST_1));
         assertThat(stackSetOperationPreferences.regionConcurrencyType()).isEqualTo(RegionConcurrencyType.PARALLEL);
+        assertThat(stackSetOperationPreferences.concurrencyMode()).isEqualTo(ConcurrencyMode.STRICT_FAILURE_TOLERANCE);
     }
 
     @Test

--- a/aws-cloudformation-stackset/src/test/java/software/amazon/cloudformation/stackset/util/AltResourceModelAnalyzerTest.java
+++ b/aws-cloudformation-stackset/src/test/java/software/amazon/cloudformation/stackset/util/AltResourceModelAnalyzerTest.java
@@ -168,7 +168,7 @@ public class AltResourceModelAnalyzerTest {
                         new HashSet<>(Arrays.asList(region_1, region_2, region_3)))
         )));
         List<String> regionOrder = Arrays.asList(region_3, region_2, region_1);
-        currentModel.setOperationPreferences(new OperationPreferences(null, null, null, null, regionOrder, null));
+        currentModel.setOperationPreferences(new OperationPreferences(null, null, null, null, regionOrder, null, null));
 
         Set<StackInstances> desiredDeleteInstances = new LinkedHashSet<>();
         Set<StackInstances> desiredCreateInstances = new LinkedHashSet<>(Arrays.asList(
@@ -199,7 +199,7 @@ public class AltResourceModelAnalyzerTest {
                         new HashSet<>(Arrays.asList(region_1, region_2, region_3)))
         )));
         List<String> regionOrder = Arrays.asList(region_3, region_2, region_1);
-        currentModel.setOperationPreferences(new OperationPreferences(null, null, null, null, regionOrder, null));
+        currentModel.setOperationPreferences(new OperationPreferences(null, null, null, null, regionOrder, null, null));
         currentModel.setManagedExecution(new ManagedExecution(true));
 
         Set<StackInstances> desiredDeleteInstances = new LinkedHashSet<>();
@@ -231,7 +231,7 @@ public class AltResourceModelAnalyzerTest {
                         new HashSet<>(Arrays.asList(region_1, region_2, region_3)))
         )));
         List<String> regionOrder = Arrays.asList(region_3);
-        currentModel.setOperationPreferences(new OperationPreferences(null, null, null, null, regionOrder, null));
+        currentModel.setOperationPreferences(new OperationPreferences(null, null, null, null, regionOrder, null, null));
 
         Set<StackInstances> desiredDeleteInstances = new LinkedHashSet<>();
         Set<StackInstances> desiredCreateInstances = new LinkedHashSet<>(Arrays.asList(
@@ -261,7 +261,7 @@ public class AltResourceModelAnalyzerTest {
                         new HashSet<>(Arrays.asList(region_1, region_2)))
         )));
         List<String> regionOrder = Arrays.asList(region_3);
-        currentModel.setOperationPreferences(new OperationPreferences(null, null, null, null, regionOrder, null));
+        currentModel.setOperationPreferences(new OperationPreferences(null, null, null, null, regionOrder, null, null));
 
         Set<StackInstances> desiredDeleteInstances = new LinkedHashSet<>();
         Set<StackInstances> desiredCreateInstances = new LinkedHashSet<>(Arrays.asList(
@@ -291,7 +291,7 @@ public class AltResourceModelAnalyzerTest {
                         new HashSet<>(Arrays.asList(region_1, region_2)))
         )));
         List<String> regionOrder = Arrays.asList(region_3, region_2, region_1);
-        currentModel.setOperationPreferences(new OperationPreferences(null, null, null, null, regionOrder, null));
+        currentModel.setOperationPreferences(new OperationPreferences(null, null, null, null, regionOrder, null, null));
 
         Set<StackInstances> desiredDeleteInstances = new LinkedHashSet<>();
         Set<StackInstances> desiredCreateInstances = new LinkedHashSet<>(Arrays.asList(
@@ -321,7 +321,7 @@ public class AltResourceModelAnalyzerTest {
                         new HashSet<>(Arrays.asList(region_1, region_2, region_3)))
         )));
         List<String> regionOrder = Arrays.asList(region_3, region_2, region_1);
-        previousModel.setOperationPreferences(new OperationPreferences(null, null, null, null, regionOrder, null));
+        previousModel.setOperationPreferences(new OperationPreferences(null, null, null, null, regionOrder, null, null));
 
         Set<StackInstances> desiredDeleteInstances = new LinkedHashSet<>(Arrays.asList(
                 generateInstancesWithRegions(Arrays.asList(OU_2, OU_3), Arrays.asList(account_1, account_2), INTER, region_3),
@@ -376,7 +376,7 @@ public class AltResourceModelAnalyzerTest {
                         Arrays.asList(OU_2, OU_3), Arrays.asList(account_1, account_2), INTER,
                         new HashSet<>(Arrays.asList(region_1, region_2, region_3)))
         )));
-        currentModel.setOperationPreferences(new OperationPreferences(null, null, null, null, null, null));
+        currentModel.setOperationPreferences(new OperationPreferences(null, null, null, null, null, null, null));
 
         Set<StackInstances> desiredDeleteInstances = new LinkedHashSet<>();
         Set<StackInstances> desiredCreateInstances = new LinkedHashSet<>(Arrays.asList(
@@ -401,7 +401,7 @@ public class AltResourceModelAnalyzerTest {
                         Arrays.asList(OU_2, OU_3), Arrays.asList(account_1, account_2), INTER,
                         new HashSet<>(Arrays.asList(region_1, region_2, region_3)))
         )));
-        previousModel.setOperationPreferences(new OperationPreferences(null, null, null, null, null, null));
+        previousModel.setOperationPreferences(new OperationPreferences(null, null, null, null, null, null, null));
 
         Set<StackInstances> desiredCreateInstances = new LinkedHashSet<>();
         Set<StackInstances> desiredDeleteInstances = new LinkedHashSet<>(Arrays.asList(
@@ -492,7 +492,7 @@ public class AltResourceModelAnalyzerTest {
                         new HashSet<>(Arrays.asList(region_1, region_2, region_4)))
         )));
         List<String> regionOrder = Arrays.asList(region_4, region_3, region_2, region_1);
-        OperationPreferences operationPreferences = new OperationPreferences(null, null, null, null, regionOrder, null);
+        OperationPreferences operationPreferences = new OperationPreferences(null, null, null, null, regionOrder, null, null);
         currentModel.setOperationPreferences(operationPreferences);
         previousModel.setOperationPreferences(operationPreferences);
 

--- a/aws-cloudformation-stackset/src/test/java/software/amazon/cloudformation/stackset/util/TestUtils.java
+++ b/aws-cloudformation-stackset/src/test/java/software/amazon/cloudformation/stackset/util/TestUtils.java
@@ -1,6 +1,7 @@
 package software.amazon.cloudformation.stackset.util;
 
 import com.google.common.collect.ImmutableMap;
+import software.amazon.awssdk.services.cloudformation.model.ConcurrencyMode;
 import software.amazon.awssdk.services.cloudformation.model.CreateStackInstancesResponse;
 import software.amazon.awssdk.services.cloudformation.model.CreateStackSetResponse;
 import software.amazon.awssdk.services.cloudformation.model.DeleteStackInstancesResponse;
@@ -199,6 +200,7 @@ public class TestUtils {
             .maxConcurrentPercentage(100)
             .regionOrder(Arrays.asList(US_WEST_1, US_EAST_1))
             .regionConcurrencyType(RegionConcurrencyType.PARALLEL.toString())
+            .concurrencyMode(ConcurrencyMode.STRICT_FAILURE_TOLERANCE.toString())
             .build();
 
     public final static ManagedExecution MANAGED_EXECUTION_ENABLED_RESOURCE_MODEL = ManagedExecution.builder()


### PR DESCRIPTION
*Description of changes:* This PR adds the ConcurrencyMode parameter to the AWS::CloudFormation::StackSet resource.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
