### PR TITLE
Only run OU and Account list validations if ALT was enabled

### DIFF
--- a/aws-cloudformation-stackset/src/main/java/software/amazon/cloudformation/stackset/util/AltResourceModelAnalyzer.java
+++ b/aws-cloudformation-stackset/src/main/java/software/amazon/cloudformation/stackset/util/AltResourceModelAnalyzer.java
@@ -16,6 +16,8 @@ import software.amazon.cloudformation.stackset.Parameter;
 import software.amazon.cloudformation.stackset.ResourceModel;
 import software.amazon.cloudformation.stackset.StackInstances;
 
+import static software.amazon.cloudformation.stackset.util.Comparator.isAccountLevelTargetingEnabled;
+
 @Builder
 @Data
 public class AltResourceModelAnalyzer {
@@ -40,8 +42,8 @@ public class AltResourceModelAnalyzer {
         Set<StackInstances> currentStackInstancesGroup = currentModel == null ?
                 new HashSet<>() : currentModel.getStackInstancesGroup();
 
-        Validator.validateServiceMangedInstancesGroup(previousStackInstancesGroup);
-        Validator.validateServiceMangedInstancesGroup(currentStackInstancesGroup);
+        Validator.validateServiceMangedInstancesGroup(previousStackInstancesGroup, isAccountLevelTargetingEnabled(previousModel));
+        Validator.validateServiceMangedInstancesGroup(currentStackInstancesGroup, isAccountLevelTargetingEnabled(currentModel));
 
         Set<String> previousModelRegionOrder = new LinkedHashSet<>();
         Set<String> currentModelRegionOrder = new LinkedHashSet<>();

--- a/aws-cloudformation-stackset/src/main/java/software/amazon/cloudformation/stackset/util/Validator.java
+++ b/aws-cloudformation-stackset/src/main/java/software/amazon/cloudformation/stackset/util/Validator.java
@@ -76,15 +76,15 @@ public class Validator {
         }
     }
 
-    public static void validateServiceMangedInstancesGroup (final Collection<StackInstances> stackInstancesGroup) {
+    public static void validateServiceMangedInstancesGroup (final Collection<StackInstances> stackInstancesGroup, boolean isAlt) {
         if (CollectionUtils.isNullOrEmpty(stackInstancesGroup)) return;
 
         stackInstancesGroup.forEach(it ->
-                validateServiceManagedDeploymentTarget(it.getDeploymentTargets())
+                validateServiceManagedDeploymentTarget(it.getDeploymentTargets(), isAlt)
         );
     }
 
-    public static void validateServiceManagedDeploymentTarget (DeploymentTargets targets) {
+    public static void validateServiceManagedDeploymentTarget (DeploymentTargets targets, boolean isAlt) {
 
         if (targets == null) {
             throw new CfnInvalidRequestException("DeploymentTargets should be specified");
@@ -106,7 +106,7 @@ public class Validator {
         final Set<String> accounts = CollectionUtils.isNullOrEmpty(targets.getAccounts()) ?
                 new HashSet<>() : targets.getAccounts();
 
-        if (Objects.equals(filter, NONE) && !CollectionUtils.isNullOrEmpty(accounts)) {
+        if (isAlt && (Objects.equals(filter, NONE) && !CollectionUtils.isNullOrEmpty(accounts))) {
             throw new CfnInvalidRequestException("AccountFilterType should be specified when both OrganizationalUnitIds and Accounts are provided");
         }
 

--- a/aws-cloudformation-stackset/src/test/java/software/amazon/cloudformation/stackset/util/AltResourceModelAnalyzerTest.java
+++ b/aws-cloudformation-stackset/src/test/java/software/amazon/cloudformation/stackset/util/AltResourceModelAnalyzerTest.java
@@ -59,15 +59,6 @@ public class AltResourceModelAnalyzerTest {
         ResourceModel modelNoneFilter = generateModel(new HashSet<>(Arrays.asList(
                 generateInstances(OU_1, account_1, NONE))));
 
-        ResourceModel modelNullFilter = generateModel(new HashSet<>(Arrays.asList(
-                StackInstances.builder().deploymentTargets(
-                                DeploymentTargets.builder()
-                                        .organizationalUnitIds(new HashSet<>(Arrays.asList(OU_1)))
-                                        .accounts(new HashSet<>(Arrays.asList(account_1)))
-                                        .build())
-                        .build()
-        )));
-
         ResourceModel modelPartiallyInvalid = generateModel(new HashSet<>(Arrays.asList(
                 generateInstances(OU_1, account_1, INTER),
                 generateInstances(OU_1, account_1, NONE))));
@@ -94,12 +85,6 @@ public class AltResourceModelAnalyzerTest {
         ex = assertThrows(
                 CfnInvalidRequestException.class,
                 () -> AltResourceModelAnalyzer.builder().currentModel(modelNoneFilter).build().analyze(placeHolder)
-        );
-        assertThat(ex.getMessage()).contains("AccountFilterType should be specified when both OrganizationalUnitIds and Accounts are provided");
-
-        ex = assertThrows(
-                CfnInvalidRequestException.class,
-                () -> AltResourceModelAnalyzer.builder().currentModel(modelNullFilter).build().analyze(placeHolder)
         );
         assertThat(ex.getMessage()).contains("AccountFilterType should be specified when both OrganizationalUnitIds and Accounts are provided");
 


### PR DESCRIPTION
*Issue #, if available:*
It is possible for subsequent operations to fail if the previous operation had an account list + OU list but no filter specified and the current operation has all three specified. This change updates our validation logic to only apply these validations during ALT since that is when both lists are applicable.
*Description of changes:*
Updated validations to only happen for ALT operations.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
