### PR TITLE
Throw retryable exceptions if another operation is in progress when a…

### DIFF
--- a/aws-cloudformation-stackset/src/main/java/software/amazon/cloudformation/stackset/BaseHandlerStd.java
+++ b/aws-cloudformation-stackset/src/main/java/software/amazon/cloudformation/stackset/BaseHandlerStd.java
@@ -2,6 +2,7 @@ package software.amazon.cloudformation.stackset;
 
 import com.google.common.annotations.VisibleForTesting;
 import software.amazon.awssdk.awscore.AwsRequest;
+import software.amazon.awssdk.core.exception.RetryableException;
 import software.amazon.awssdk.services.cloudformation.CloudFormationClient;
 import software.amazon.awssdk.services.cloudformation.model.CreateStackInstancesResponse;
 import software.amazon.awssdk.services.cloudformation.model.DeleteStackInstancesResponse;
@@ -297,7 +298,7 @@ public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
                         }
                         // If OperationInProgressException is thrown by the service, then we retry
                         if (e instanceof OperationInProgressException) {
-                            return ProgressEvent.progress(model_, context);
+                            throw RetryableException.builder().build();
                         }
                         throw e;
                     })


### PR DESCRIPTION
…ttempting to delete stack instances

*Issue #, if available:*

*Description of changes:*
A recent change to the RPDK changes the behavior of progress events such that they will no longer retry. We need to explicitly throw a retriable exception to maintain the current behavior


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
